### PR TITLE
Add filters argument for image.list()

### DIFF
--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -289,7 +289,7 @@ class ImageCLI(DockerCLICaller):
             raise DockerException(full_cmd, exit_code)
         return stdout.decode().splitlines()
 
-    def list(self) -> List[Image]:
+    def list(self, filters: Dict[str, str] = {}) -> List[Image]:
         """Returns the list of Docker images present on the machine.
 
         Alias: `docker.images()`
@@ -305,6 +305,7 @@ class ImageCLI(DockerCLICaller):
             "--quiet",
             "--no-trunc",
         ]
+        full_cmd.add_args_list("--filter", format_dict_for_cli(filters))
 
         ids = run(full_cmd).splitlines()
         # the list of tags is bigger than the number of images. We uniquify

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -37,6 +37,16 @@ def test_save_iterator_bytes():
     assert i != 0
 
 
+def test_filter_when_listing():
+    docker.pull("hello-world")
+    images_listed = docker.image.list(filters=dict(reference="hello-world"))
+    tags = set()
+    for image in images_listed:
+        for tag in image.repo_tags:
+            tags.add(tag)
+    assert tags == {"hello-world:latest"}
+
+
 def test_save_iterator_bytes_fails():
     docker.image.pull("busybox:1", quiet=True)
     iterator = docker.image.save("busybox:42")


### PR DESCRIPTION
- Added a simple `filters=dict` argument to your `image.list()` function.
- It follows the same format as your `container.list()` function.

I didn't write the test codes for it since I haven't really studied your test codes yet. If you could tell me what is the best approach, I would implement it. I was thinking on the line of using `docker.build(..., labels={"foo": "bar", ...}, ...)` and listing out the images using `docker.image.list(fitlers={"label": "foo=bar"})` and checking for the number to match. I looked into `test_image.py`, but couldn't fully understand how you would go about in an optimal way.

