### PR TITLE
Set threads in stream_stdout_and_stderr as daemons to avoid blocking ctrl+c

### DIFF
--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -219,8 +219,12 @@ def stream_stdout_and_stderr(
     process = Popen(full_cmd, stdout=PIPE, stderr=PIPE, env=subprocess_env)
     q = Queue()
     full_stderr = b""  # for the error message
-    Thread(target=reader, args=[process.stdout, "stdout", q]).start()
-    Thread(target=reader, args=[process.stderr, "stderr", q]).start()
+    th = Thread(target=reader, args=[process.stdout, "stdout", q])
+    th.daemon = True
+    th.start()
+    th = Thread(target=reader, args=[process.stderr, "stderr", q])
+    th.daemon = True
+    th.start()
     for _ in range(2):
         for source, line in iter(q.get, None):
             yield source, line

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -219,6 +219,7 @@ def stream_stdout_and_stderr(
     process = Popen(full_cmd, stdout=PIPE, stderr=PIPE, env=subprocess_env)
     q = Queue()
     full_stderr = b""  # for the error message
+    # we use deamon threads to avoid hanging if the user uses ctrl+c
     th = Thread(target=reader, args=[process.stdout, "stdout", q])
     th.daemon = True
     th.start()


### PR DESCRIPTION
I don't know why I didn't notice this before, but logs --follow prevents ctrl+c to properly works

After ctrl+c the KeyboardInterrupt exception is properly raised but the python interpreter seems to remain stuck
A second ctrl+c is needed to go back to the shell

I found this interesting post from Miguel Grinberg explaining very clearly the difference between threads and daemon threads
https://blog.miguelgrinberg.com/post/how-to-kill-a-python-thread

And I verified that by setting the two threads used in stream_stdout_and_stderr as daemons the ctrl+c starts to work as expected

If you don't see any dangerous side effects, this pull request fixes the problem by setting the two threads as daemons

Potential side effects are documented in the python guide (https://docs.python.org/3/library/threading.html#thread-objects):

_Note Daemon threads are abruptly stopped at shutdown. Their resources (such as open files, database transactions, etc.) may not be released properly. If you want your threads to stop gracefully, make them non-daemonic and use a suitable signalling mechanism such as an Event._

Feel free to drop this pull request if you prefer to go in Events direction