### PR TITLE
handling filter option uniformly

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1027,8 +1027,7 @@ class ContainerCLI(DockerCLICaller):
             filters: Filters as strings or list of strings
         """
         full_cmd = self.docker_cmd + ["container", "prune", "--force"]
-        for filter_ in to_list(filters):
-            full_cmd += ["--filter", filter_]
+        full_cmd.add_args_list("--filter", format_dict_for_cli(filters))
         run(full_cmd)
 
     def rename(self, container: ValidContainer, new_name: str) -> None:

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1020,7 +1020,7 @@ class ContainerCLI(DockerCLICaller):
 
         run(full_cmd)
 
-    def prune(self, filters: Union[str, List[str]] = []) -> None:
+    def prune(self, filters: Dict[str, str] = {}) -> None:
         """Remove containers that are not running.
 
         # Arguments

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1026,6 +1026,12 @@ class ContainerCLI(DockerCLICaller):
         # Arguments
             filters: Filters as strings or list of strings
         """
+        if isinstance(filter, list):
+            raise TypeError(
+                "since python-on-whales 0.38.0, the filter argument is expected to be "
+                "a dict, not a list, please replace your function call by "
+                "docker.container.prune(filters={...})"
+            )
         full_cmd = self.docker_cmd + ["container", "prune", "--force"]
         full_cmd.add_args_list("--filter", format_dict_for_cli(filters))
         run(full_cmd)

--- a/python_on_whales/components/volume/cli_wrapper.py
+++ b/python_on_whales/components/volume/cli_wrapper.py
@@ -17,7 +17,7 @@ from python_on_whales.client_config import (
 from python_on_whales.components.volume.models import VolumeInspectResult
 from python_on_whales.exceptions import NoSuchVolume
 from python_on_whales.test_utils import random_name
-from python_on_whales.utils import ValidPath, run, to_list
+from python_on_whales.utils import ValidPath, format_dict_for_cli, run, to_list
 
 
 class Volume(ReloadableObjectFromJson):
@@ -181,9 +181,7 @@ class VolumeCLI(DockerCLICaller):
         """
 
         full_cmd = self.docker_cmd + ["volume", "list", "--quiet"]
-
-        for key, value in filters.items():
-            full_cmd += ["--filter", f"{key}={value}"]
+        full_cmd.add_args_list("--filter", format_dict_for_cli(filters))
 
         volumes_names = run(full_cmd).splitlines()
 

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -588,3 +588,26 @@ def test_rename_nosuchcontainer():
 def test_update_nosuchcontainer():
     with pytest.raises(NoSuchContainer):
         docker.container.update("grueighuri", cpus=4)
+
+
+def test_prune():
+    for container in docker.container.list(filters={"name": "test-container"}):
+        docker.container.remove(container, force=True)
+    container = docker.container.create("busybox")
+    assert container in docker.container.list()
+
+    # container not pruned because it does not have matching name
+    docker.container.prune(filters={"name": "dne"})
+    assert container in docker.container.list()
+
+    # container not pruned because it does not have matching name
+    docker.container.prune(filters={"status": "running"})
+    assert container in docker.container.list()
+
+    # container not pruned because it does not have matching name
+    docker.container.prune(filters={"name": "dne", "status": "running"})
+    assert container in docker.container.list()
+
+    # container pruned
+    docker.container.prune()
+    assert container not in docker.container.list()

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -594,20 +594,20 @@ def test_prune():
     for container in docker.container.list(filters={"name": "test-container"}):
         docker.container.remove(container, force=True)
     container = docker.container.create("busybox")
-    assert container in docker.container.list()
+    assert container in docker.container.list(all=True)
 
-    # container not pruned because it does not have matching name
-    docker.container.prune(filters={"name": "dne"})
-    assert container in docker.container.list()
+    # container not pruned because it is not old enough
+    docker.container.prune(filters={"until": "100h"})
+    assert container in docker.container.list(all=True)
 
-    # container not pruned because it does not have matching name
-    docker.container.prune(filters={"status": "running"})
-    assert container in docker.container.list()
+    # container not pruned because it is does not have label "dne"
+    docker.container.prune(filters={"label": "dne"})
+    assert container in docker.container.list(all=True)
 
-    # container not pruned because it does not have matching name
-    docker.container.prune(filters={"name": "dne", "status": "running"})
-    assert container in docker.container.list()
+    # container not pruned because it is not old enough and does not have label "dne"
+    docker.container.prune(filters={"until": "100h", "label": "dne"})
+    assert container in docker.container.list(all=True)
 
     # container pruned
     docker.container.prune()
-    assert container not in docker.container.list()
+    assert container not in docker.container.list(all=True)

--- a/tests/python_on_whales/components/test_system.py
+++ b/tests/python_on_whales/components/test_system.py
@@ -50,6 +50,14 @@ def test_prune_prunes_image():
     assert image in docker.image.list()
 
     # image not pruned because it does not have dne label
+    docker.system.prune(all=True, filters={"label": "dne"})
+    assert image in docker.image.list()
+
+    # image not pruned because it is not 1000000 hours old
+    docker.system.prune(all=True, filters={"until": "1000000h"})
+    assert image in docker.image.list()
+
+    # image not pruned because it does not have dne label and is not 1000000 hours old
     docker.system.prune(all=True, filters={"label": "dne", "until": "1000000h"})
     assert image in docker.image.list()
 

--- a/tests/python_on_whales/components/test_system.py
+++ b/tests/python_on_whales/components/test_system.py
@@ -50,7 +50,7 @@ def test_prune_prunes_image():
     assert image in docker.image.list()
 
     # image not pruned because it does not have dne label
-    docker.system.prune(all=True, filters={"label": "dne"})
+    docker.system.prune(all=True, filters={"label": "dne", "until": "1000000h"})
     assert image in docker.image.list()
 
     # image pruned

--- a/tests/python_on_whales/components/test_volume.py
+++ b/tests/python_on_whales/components/test_volume.py
@@ -192,3 +192,26 @@ def test_volume_exists():
     with docker.volume.create() as v:
         assert v.exists()
         assert docker.volume.exists(v.name)
+
+
+def test_prune():
+    for container in docker.container.list(filters={"name": "test-volume"}):
+        docker.container.remove(container, force=True)
+    volume = docker.volume.create("test-volume")
+    assert volume in docker.volume.list()
+
+    # volume not pruned because it does not have matching name
+    docker.volume.prune(filters={"name": "dne"})
+    assert volume in docker.volume.list()
+
+    # volume not pruned because it does not have matching name
+    docker.volume.prune(filters={"label": "some-label"})
+    assert volume in docker.volume.list()
+
+    # volume not pruned because it does not have matching name
+    docker.volume.prune(filters={"name": "dne", "label": "some-label"})
+    assert volume in docker.volume.list()
+
+    # volume pruned
+    docker.volume.prune()
+    assert volume not in docker.volume.list()

--- a/tests/python_on_whales/components/test_volume.py
+++ b/tests/python_on_whales/components/test_volume.py
@@ -200,17 +200,11 @@ def test_prune():
     volume = docker.volume.create("test-volume")
     assert volume in docker.volume.list()
 
-    # volume not pruned because it does not have matching name
-    docker.volume.prune(filters={"name": "dne"})
+    # volume not pruned because it is does not have label "dne"
+    docker.volume.prune(filters={"label": "dne"})
     assert volume in docker.volume.list()
 
-    # volume not pruned because it does not have matching name
-    docker.volume.prune(filters={"label": "some-label"})
-    assert volume in docker.volume.list()
-
-    # volume not pruned because it does not have matching name
-    docker.volume.prune(filters={"name": "dne", "label": "some-label"})
-    assert volume in docker.volume.list()
+    # could only find "label" filter for `docker volume prune`
 
     # volume pruned
     docker.volume.prune()


### PR DESCRIPTION
THIS PR CONTAINS CHANGES THAT ARE NOT BACKWARDS COMPATIBLE

1. Uses dictionary for filters in `container.prune` (NOT BACKWARDS COMPATIBLE)
2. Adds multi-filter prune to system test
3. slight refactor of volume prune.