### PR TITLE
Add project_urls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,9 @@ setup(
             "python-on-whales=python_on_whales.command_line_entrypoint:main"
         ],
     },
+    project_urls={
+        "Documentation": "https://gabrieldemarmiesse.github.io/python-on-whales/",
+        "Source Code": "https://github.com/gabrieldemarmiesse/python-on-whales",
+        "Bug Tracker": "https://github.com/gabrieldemarmiesse/python-on-whales/issues",
+    },
 )


### PR DESCRIPTION
Add project_urls from https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls

The string of the key is the exact text that will be displayed on PyPI.