### PR TITLE
capturing stdout and stderr for docker volume prune

### DIFF
--- a/python_on_whales/components/volume/cli_wrapper.py
+++ b/python_on_whales/components/volume/cli_wrapper.py
@@ -202,7 +202,7 @@ class VolumeCLI(DockerCLICaller):
         for key, value in filters.items():
             full_cmd += ["--filter", f"{key}={value}"]
 
-        run(full_cmd, capture_stderr=False, capture_stdout=False)
+        run(full_cmd)
 
     def remove(self, x: Union[ValidVolume, List[ValidVolume]]):
         """Removes one or more volumes


### PR DESCRIPTION
I made the stdout/stderr handling for `docker.volume.prune` the same as the others.

The larger issue of how to uniformly handle stderr and stdout in an interesting one but well outside the scope of this PR.