### PR TITLE
Add flags to docker compose pull

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -245,15 +245,25 @@ class ComposeCLI(DockerCLICaller):
         Container = python_on_whales.components.container.cli_wrapper.Container
         return [Container(self.client_config, x, is_immutable_id=True) for x in ids]
 
-    def pull(self, services: List[str] = []):
+    def pull(
+        self,
+        services: List[str] = [],
+        ignore_pull_failures: bool = False,
+        include_deps: bool = False,
+    ):
         """Pull service images
 
         # Arguments
             services: The list of services to select. Only the images of those
                 services will be pulled. If no services are specified (the default
                 behavior) all images of all services are pulled.
+            ignore_pull_failures: Pull what it can and ignores images with pull failures
+            include_deps: Also pull services declared as dependencies
+
         """
         full_cmd = self.docker_compose_cmd + ["pull"]
+        full_cmd.add_flag("--ignore-pull-failures", ignore_pull_failures)
+        full_cmd.add_flag("--include-deps", include_deps)
         full_cmd += services
         run(full_cmd)
 

--- a/tests/python_on_whales/components/dummy_compose.yml
+++ b/tests/python_on_whales/components/dummy_compose.yml
@@ -17,11 +17,9 @@ services:
     command: sleep infinity
   busybox-2-electric-boogaloo:
     image: busybox:latest
-    depends:
+    depends_on:
       - alpine
     command: sleep infinity
-  ghost:
-    image: i_do_not_exist:v0.0.1
   alpine:
     image: alpine:latest
     command: sleep infinity

--- a/tests/python_on_whales/components/dummy_compose.yml
+++ b/tests/python_on_whales/components/dummy_compose.yml
@@ -15,6 +15,13 @@ services:
   busybox:
     image: busybox:latest
     command: sleep infinity
+  busybox-2-electric-boogaloo:
+    image: busybox:latest
+    depends:
+      - alpine
+    command: sleep infinity
+  ghost:
+    image: i_do_not_exist:v0.0.1
   alpine:
     image: alpine:latest
     command: sleep infinity

--- a/tests/python_on_whales/components/dummy_compose_non_existent_image.yml
+++ b/tests/python_on_whales/components/dummy_compose_non_existent_image.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  busybox:
+    image: busybox:latest
+    command: sleep infinity
+  ghost:
+      image: busybox:i-do-not-exist

--- a/tests/python_on_whales/components/dummy_compose_non_existent_image.yml
+++ b/tests/python_on_whales/components/dummy_compose_non_existent_image.yml
@@ -5,4 +5,6 @@ services:
     image: busybox:latest
     command: sleep infinity
   ghost:
-      image: busybox:i-do-not-exist
+    build:
+      context: ghost_context
+    image: i-definitely-do-not-exist

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -222,12 +222,17 @@ def test_docker_compose_pull():
     "the CI. We get a .dockercfg: $HOME is not defined.",
 )
 def test_docker_compose_pull_ignore_pull_failures():
+    docker = DockerClient(
+        compose_files=[
+            PROJECT_ROOT
+            / "tests/python_on_whales/components/dummy_compose_non_existent_image.yml"
+        ]
+    )
     try:
-        docker.image.remove("busybox")
+        docker.image.remove("ghost")
     except NoSuchImage:
         pass
-    docker.compose.pull(["busybox", "ghost"], ignore_pull_failures=True)
-    docker.image.inspect(["busybox"])
+    docker.compose.pull(["ghost"], ignore_pull_failures=True)
 
 
 @pytest.mark.skipif(

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -198,11 +198,6 @@ def test_docker_compose_kill():
     docker.compose.down()
 
 
-@pytest.mark.skipif(
-    True,
-    reason="TODO: Fixme. For some reason it works locally but not in "
-    "the CI. We get a .dockercfg: $HOME is not defined.",
-)
 def test_docker_compose_pull():
     try:
         docker.image.remove("busybox")
@@ -216,11 +211,6 @@ def test_docker_compose_pull():
     docker.image.inspect(["busybox", "alpine"])
 
 
-@pytest.mark.skipif(
-    True,
-    reason="TODO: Fixme. For some reason it works locally but not in "
-    "the CI. We get a .dockercfg: $HOME is not defined.",
-)
 def test_docker_compose_pull_ignore_pull_failures():
     docker = DockerClient(
         compose_files=[
@@ -235,18 +225,13 @@ def test_docker_compose_pull_ignore_pull_failures():
     docker.compose.pull(["ghost"], ignore_pull_failures=True)
 
 
-@pytest.mark.skipif(
-    True,
-    reason="TODO: Fixme. For some reason it works locally but not in "
-    "the CI. We get a .dockercfg: $HOME is not defined.",
-)
 def test_docker_compose_pull_include_deps():
     try:
         docker.image.remove("alpine")
     except NoSuchImage:
         pass
     docker.compose.pull(["busybox-2-electric-boogaloo"], include_deps=True)
-    docker.image.inspect(["alpine", "busybox-2-electric-boogaloo"])
+    docker.image.inspect(["alpine"])
 
 
 def test_docker_compose_up_abort_on_container_exit():

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -216,6 +216,34 @@ def test_docker_compose_pull():
     docker.image.inspect(["busybox", "alpine"])
 
 
+@pytest.mark.skipif(
+    True,
+    reason="TODO: Fixme. For some reason it works locally but not in "
+    "the CI. We get a .dockercfg: $HOME is not defined.",
+)
+def test_docker_compose_pull_ignore_pull_failures():
+    try:
+        docker.image.remove("busybox")
+    except NoSuchImage:
+        pass
+    docker.compose.pull(["busybox", "ghost"], ignore_pull_failures=True)
+    docker.image.inspect(["busybox"])
+
+
+@pytest.mark.skipif(
+    True,
+    reason="TODO: Fixme. For some reason it works locally but not in "
+    "the CI. We get a .dockercfg: $HOME is not defined.",
+)
+def test_docker_compose_pull_include_deps():
+    try:
+        docker.image.remove("alpine")
+    except NoSuchImage:
+        pass
+    docker.compose.pull(["busybox-2-electric-boogaloo"], include_deps=True)
+    docker.image.inspect(["alpine", "busybox-2-electric-boogaloo"])
+
+
 def test_docker_compose_up_abort_on_container_exit():
     docker = DockerClient(
         compose_files=[


### PR DESCRIPTION
This PR adds the following flags to `docker.compose.pull` as optional keyword arguments:
```
--ignore-pull-failures
--include-deps
```

The test for `docker.compose.pull` skips so I have added the same skip to the new tests.  Presumably they would fail for the same reason