### PR TITLE
Task/add boolean to run docker compose in compatibility mode

### DIFF
--- a/python_on_whales/client_config.py
+++ b/python_on_whales/client_config.py
@@ -58,6 +58,7 @@ class ClientConfig:
     compose_profiles: List[str] = field(default_factory=list)
     compose_env_file: Optional[ValidPath] = None
     compose_project_name: Optional[str] = None
+    compose_compatibility: Optional[bool] = None
 
     def get_docker_path(self) -> ValidPath:
         if self.client_binary_path is None:
@@ -125,6 +126,7 @@ class ClientConfig:
         base_cmd.add_args_list("--profile", self.compose_profiles)
         base_cmd.add_simple_arg("--env-file", self.compose_env_file)
         base_cmd.add_simple_arg("--project-name", self.compose_project_name)
+        base_cmd.add_flag("--compatibility", self.compose_compatibility)
         return base_cmd
 
 

--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -57,6 +57,7 @@ class DockerClient(DockerCLICaller):
             into the compose project. By default, it uses `./.env`.
         compose_project_name: The name of the compose project. It will be prefixed to
             networks, volumes and containers created by compose.
+        compose_compatibility: Use docker compose in compatibility mode.
     """
 
     def __init__(
@@ -76,6 +77,7 @@ class DockerClient(DockerCLICaller):
         compose_profiles: List[str] = [],
         compose_env_file: Optional[ValidPath] = None,
         compose_project_name: Optional[str] = None,
+        compose_compatibility: Optional[bool] = None,
     ):
 
         if client_config is None:
@@ -94,6 +96,7 @@ class DockerClient(DockerCLICaller):
                 compose_profiles=compose_profiles,
                 compose_env_file=compose_env_file,
                 compose_project_name=compose_project_name,
+                compose_compatibility=compose_compatibility,
             )
         super().__init__(client_config)
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -6,7 +6,7 @@ RUN chmod a+x /docker-buildx
 #-----------------------------------------------------------------------------
 FROM busybox as get_compose
 
-RUN wget -O /docker-compose https://github.com/docker/compose-cli/releases/download/v2.0.0-beta.6/docker-compose-linux-amd64
+RUN wget -O /docker-compose https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64
 RUN chmod a+x /docker-compose
 
 

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -19,7 +19,10 @@ pytestmark = pytest.mark.skipif(
 )
 
 docker = DockerClient(
-    compose_files=[PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"]
+    compose_files=[
+        PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
+    ],
+    compose_compatibility=True,
 )
 
 
@@ -33,6 +36,7 @@ def test_compose_project_name():
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
         ],
         compose_project_name="dudu",
+        compose_compatibility=True,
     )
     docker.compose.up(["busybox", "alpine"], detach=True)
     containers = docker.compose.ps()
@@ -52,7 +56,8 @@ def test_docker_compose_up_down():
         compose_files=[
             PROJECT_ROOT
             / "tests/python_on_whales/components/dummy_compose_ends_quickly.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(["busybox", "alpine"])
     docker.compose.down(timeout=1)
@@ -221,7 +226,8 @@ def test_docker_compose_up_abort_on_container_exit():
         compose_files=[
             PROJECT_ROOT
             / "tests/python_on_whales/components/dummy_compose_ends_quickly.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(["alpine"], abort_on_container_exit=True)
     for container in docker.compose.ps():
@@ -238,6 +244,7 @@ def test_passing_env_files(tmp_path: Path):
             / "tests/python_on_whales/components/dummy_compose_ends_quickly.yml"
         ],
         compose_env_file=compose_env_file,
+        compose_compatibility=True,
     )
     output = docker.compose.config()
 
@@ -253,7 +260,7 @@ def test_config_complexe_compose():
     compose_file = (
         PROJECT_ROOT / "tests/python_on_whales/components/complexe-compose.yml"
     )
-    docker = DockerClient(compose_files=[compose_file])
+    docker = DockerClient(compose_files=[compose_file], compose_compatibility=True)
     config = docker.compose.config()
 
     assert (
@@ -297,7 +304,7 @@ def test_compose_down_volumes():
     compose_file = (
         PROJECT_ROOT / "tests/python_on_whales/components/complexe-compose.yml"
     )
-    docker = DockerClient(compose_files=[compose_file])
+    docker = DockerClient(compose_files=[compose_file], compose_compatibility=True)
     docker.compose.up(
         ["my_service"], detach=True, scales=dict(my_service=1), build=True
     )
@@ -345,7 +352,8 @@ def test_compose_logs_simple_use_case():
     docker = DockerClient(
         compose_files=[
             PROJECT_ROOT / "tests/python_on_whales/components/compose_logs.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(detach=True)
     # Wait some seconds to let the container to complete the execution of ping
@@ -361,7 +369,8 @@ def test_compose_logs_stream():
     docker = DockerClient(
         compose_files=[
             PROJECT_ROOT / "tests/python_on_whales/components/compose_logs.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(detach=True)
     time.sleep(15)
@@ -379,7 +388,8 @@ def test_compose_logs_follow():
     docker = DockerClient(
         compose_files=[
             PROJECT_ROOT / "tests/python_on_whales/components/compose_logs.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(detach=True)
 
@@ -414,7 +424,8 @@ def test_compose_execute_no_tty(privileged):
     docker = DockerClient(
         compose_files=[
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(["busybox"], detach=True)
     time.sleep(2)
@@ -429,7 +440,8 @@ def test_compose_execute_with_tty():
     docker = DockerClient(
         compose_files=[
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(["busybox"], detach=True)
     time.sleep(2)
@@ -442,7 +454,8 @@ def test_compose_execute_detach():
     docker = DockerClient(
         compose_files=[
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(["busybox"], detach=True)
     t1 = datetime.now()
@@ -457,7 +470,8 @@ def test_compose_execute_envs():
     docker = DockerClient(
         compose_files=[
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(["busybox"], detach=True)
     output = docker.compose.execute(
@@ -474,7 +488,8 @@ def test_compose_execute_user():
     docker = DockerClient(
         compose_files=[
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(["busybox"], detach=True)
     output = docker.compose.execute("busybox", ["whoami"], tty=False, user="sync")
@@ -486,7 +501,8 @@ def test_compose_execute_workdir():
     docker = DockerClient(
         compose_files=[
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
-        ]
+        ],
+        compose_compatibility=True,
     )
     docker.compose.up(["busybox"], detach=True)
     assert (
@@ -505,6 +521,7 @@ def test_compose_single_profile():
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
         ],
         compose_profiles=["my_test_profile"],
+        compose_compatibility=True,
     )
     docker.compose.up(detach=True)
 
@@ -520,6 +537,7 @@ def test_compose_multiple_profiles():
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
         ],
         compose_profiles=["my_test_profile", "my_test_profile2"],
+        compose_compatibility=True,
     )
     docker.compose.up(detach=True)
 


### PR DESCRIPTION
This PR adds the ability to use `docker compose` in compatibility mode.  This is done by adding `--compatibility` to the command.

I have added an optional `compose_compatibility` argument to the `DockerClient` and to the `ClientConfig` `dataclass`.

Example usage:
```python
docker = DockerClient(compose_compatibility=True)
```

This ensures the tests in `tests/python_on_whales/components/test_compose.py` succeed for all current versions 2.0.0 and above of `docker compose` 