### PR TITLE
Handle custom registry name when using ecr login

### DIFF
--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -236,7 +236,7 @@ class DockerClient(DockerCLICaller):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         region_name: Optional[str] = None,
-        registry: Optional[str] = None
+        registry: Optional[str] = None,
     ):
         """Login to the aws ECR registry. Credentials are taken from the
         environment variables as defined in
@@ -251,6 +251,10 @@ class DockerClient(DockerCLICaller):
         ```
 
         You need botocore to run this function. Use `pip install botocore` to install it.
+
+        The registry parameter can be used to override the registry that is guessed from authorization token
+        request's response. It is especially useful if the aws account you use can access several repositories and you
+        need to explicitly define the one you want to use
         """
         import botocore.session
 

--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -236,6 +236,7 @@ class DockerClient(DockerCLICaller):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         region_name: Optional[str] = None,
+        registry: Optional[str] = None
     ):
         """Login to the aws ECR registry. Credentials are taken from the
         environment variables as defined in
@@ -263,5 +264,6 @@ class DockerClient(DockerCLICaller):
         response = client.get_authorization_token()["authorizationData"][0]
         credentials = base64.b64decode(response["authorizationToken"]).decode()
         username, password = credentials.split(":")
-        registry = response["proxyEndpoint"]
+        if registry is None:
+            registry = response["proxyEndpoint"]
         self.login(registry, username, password)

--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -252,8 +252,9 @@ class DockerClient(DockerCLICaller):
 
         You need botocore to run this function. Use `pip install botocore` to install it.
 
-        The registry parameter can be used to override the registry that is guessed from authorization token
-        request's response. It is especially useful if the aws account you use can access several repositories and you
+        The `registry` parameter can be used to override the registry that is guessed from the authorization token
+        request's response.
+        It is especially useful if the aws account you use can access several repositories and you
         need to explicitly define the one you want to use
         """
         import botocore.session

--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -254,6 +254,7 @@ class DockerClient(DockerCLICaller):
 
         The `registry` parameter can be used to override the registry that is guessed from the authorization token
         request's response.
+        In other words: If the registry is `None` (the default) then it will be assumed that it's the ECR registry linked to the credentials provided.
         It is especially useful if the aws account you use can access several repositories and you
         need to explicitly define the one you want to use
         """


### PR DESCRIPTION
This PR adds support for a custom registry name when using ECR login. 
It can be used like so : 

```python
    target_registry = "my-very-special-registry"
    docker.login_ecr(
        region_name="eu-west-1",
        registry=target_registry,
    )
    docker.pull(f"{target_registry}/my-special-project:my-special-tag")
```