### PR TITLE
Allow to inspect exit_code and other info on exceptions

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -42,3 +42,4 @@ nav:
       - docker.run() guide: user_guide/docker_run.md
       - Swarm generic resources: user_guide/generic_resources.md
       - Running python-on-whales inside a container: user_guide/running_python_on_whales_inside_a_container.md
+      - dealing with exceptions: user_guide/exceptions.md

--- a/docs/template/user_guide/exceptions.md
+++ b/docs/template/user_guide/exceptions.md
@@ -1,0 +1,35 @@
+# Capturing exceptions
+
+## Exception classes
+
+Exceptions raised will be an instance of `DockerException`, or a child class for
+more specific errors.
+
+Those are the child classes:
+
+* `NoSuchContainer`
+* `NoSuchImage`
+* `NoSuchService`
+* `NotASwarmManager`
+* `NoSuchVolume`
+
+All exceptions will have these 4 attributes:
+
+* docker_command: the docker command used internally, as a list of strings.
+* return_code: the exit code docker client exited with, as an int
+* stdout: the content that docker wrote to stdout, as a string, or `None`
+* stderr: the content that docker wrote to stderr, as a string, or `None`
+
+## Example
+
+```python
+import logging
+from python_on_whales import DockerClient
+from python_on_whales.exceptions import DockerException
+
+client = DockerClient(compose_files=["/tmp/docker-compose.yml"])
+try:
+    client.execute("my-service", ["arg1", "arg2"])
+except DockerException as e:
+    print(f"Exit code {e.return_code} while running {e.docker_command}")
+```

--- a/python_on_whales/exceptions.py
+++ b/python_on_whales/exceptions.py
@@ -9,20 +9,31 @@ class DockerException(Exception):
         stdout: Optional[bytes] = None,
         stderr: Optional[bytes] = None,
     ):
+
+        self.docker_command: List[str] = command_launched
+        self.return_code: int = return_code
+        if stdout is None:
+            self.stdout: Optional[str] = None
+        else:
+            self.stdout: Optional[str] = stdout.decode()
+        if stderr is None:
+            self.stderr: Optional[str] = None
+        else:
+            self.stderr: Optional[str] = stderr.decode()
         command_launched_str = " ".join(command_launched)
         error_msg = (
             f"The docker command executed was `{command_launched_str}`.\n"
             f"It returned with code {return_code}\n"
         )
         if stdout is not None:
-            error_msg += f"The content of stdout is '{stdout.decode()}'\n"
+            error_msg += f"The content of stdout is '{self.stdout}'\n"
         else:
             error_msg += (
                 "The content of stdout can be found above the "
                 "stacktrace (it wasn't captured).\n"
             )
         if stderr is not None:
-            error_msg += f"The content of stderr is '{stderr.decode()}'\n"
+            error_msg += f"The content of stderr is '{self.stderr}'\n"
         else:
             error_msg += (
                 "The content of stderr can be found above the "

--- a/tests/python_on_whales/test_exceptions.py
+++ b/tests/python_on_whales/test_exceptions.py
@@ -1,0 +1,23 @@
+import pytest
+
+from python_on_whales import docker
+from python_on_whales.exceptions import DockerException
+
+
+def test_exception_attributes():
+    with pytest.raises(DockerException) as excinfo:
+        docker.image.tag("wrong::image", "wrong::tag")
+
+    exception = excinfo.value
+    assert "The docker command executed was" in str(exception)
+    assert exception.docker_command[1:5] == [
+        "image",
+        "tag",
+        "wrong::image",
+        "wrong::tag",
+    ]
+    # The exact return code and error string might vary with future docker
+    # versions, so following asserts are somewhat relaxed
+    assert exception.return_code > 0
+    assert not exception.stdout
+    assert "wrong::" in exception.stderr


### PR DESCRIPTION
DockerException classes format the relevant info nicely for user.

But sometimes code needs to use that info to take decisions or to digest that
for user.

For example, exit code of some `docker compose exec ...` command might be
relevant, and we would want to implement some logic that depends on exit code or
parse a json in stderr, etc.