### PR TITLE
Allow interactive container to be detached

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1444,12 +1444,6 @@ class ContainerCLI(DockerCLICaller):
 
         full_cmd.add_flag("--init", init)
 
-        # TODO: activate interactive and tty
-        if interactive and not tty:
-            raise NotImplementedError(
-                "Currently, docker.container.run(interactive=True) must have"
-                "tty=True. interactive=True and tty=False is not yet implemented."
-            )
         full_cmd.add_flag("--interactive", interactive)
         full_cmd.add_flag("--tty", tty)
 
@@ -1533,12 +1527,6 @@ class ContainerCLI(DockerCLICaller):
             if stream:
                 raise ValueError(
                     "It's not possible to stream and detach a container at "
-                    "the same time."
-                )
-        if stream and interactive:
-            if interactive:
-                raise ValueError(
-                    "It's not possible to interact and stream a container at "
                     "the same time."
                 )
         if detach:

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1535,11 +1535,6 @@ class ContainerCLI(DockerCLICaller):
                     "It's not possible to stream and detach a container at "
                     "the same time."
                 )
-            if interactive:
-                raise ValueError(
-                    "It's not possible to interact and detach a container at "
-                    "the same time."
-                )
         if stream and interactive:
             if interactive:
                 raise ValueError(

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -623,3 +623,8 @@ def test_prune():
     # container pruned
     docker.container.prune()
     assert container not in docker.container.list(all=True)
+
+
+def test_run_detached_interactive():
+    with docker.run("ubuntu", interactive=True, detach=True, tty=False) as c:
+        c.execute(["true"])


### PR DESCRIPTION
Running a container with `--interactive` (or `-i`) causes stdin to be open. This may be desirable for reasons entirely separate from whether you want to be attached/detached. For example, with `bash` as the entrypoint the container will exit if stdin is closed.

This is a hard blocker for my use-case, so I'm currently having to use a fork with this `ValueError` removed. It would be great if this could be upstreamed! Possibly even remove the `if stream and interactive` error case too (I'm less familiar with the streaming case).

Fixes #344

- [x] Add UT case