### PR TITLE
Fix image remove command

### DIFF
--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -545,7 +545,7 @@ class ImageCLI(DockerCLICaller):
 
         """
 
-        full_cmd = self.docker_cmd + ["image", "remove"]
+        full_cmd = self.docker_cmd + ["image", "rm"]
         full_cmd.add_flag("--force", force)
         full_cmd.add_flag("--no-prune", not prune)
         for image in to_list(x):


### PR DESCRIPTION
Removing docker images is implemented using `docker image remove`, which I'm assuming is a [deprecated?] hidden alias for `docker image rm`?

```
root@ubuntu:~# docker image --help

Usage:  docker image COMMAND

Manage images

Commands:
  build       Build an image from a Dockerfile
  history     Show the history of an image
  import      Import the contents from a tarball to create a filesystem image
  inspect     Display detailed information on one or more images
  load        Load an image from a tar archive or STDIN
  ls          List images
  prune       Remove unused images
  pull        Pull an image or a repository from a registry
  push        Push an image or a repository to a registry
  rm          Remove one or more images
  save        Save one or more images to a tar archive (streamed to STDOUT by default)
  tag         Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE

Run 'docker image COMMAND --help' for more information on a command.

root@ubuntu:~# docker --version
Docker version 20.10.12, build e91ed57
```

This command does not work with podman.