### PR TITLE
Change behavior of empty list as argument to some functions

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -19,7 +19,7 @@ from python_on_whales.utils import (
 class ComposeCLI(DockerCLICaller):
     def build(
         self,
-        services: List[str] = [],
+        services: Optional[List[str]] = None,
         build_args: Dict[str, str] = {},
         cache: bool = True,
         progress: Optional[str] = None,
@@ -30,8 +30,9 @@ class ComposeCLI(DockerCLICaller):
         """Build services declared in a yaml compose file.
 
         # Arguments
-            services: The services to build (as strings).
-                If empty (default), all services are built.
+            services: The services to build (as list of strings).
+                If `None` (default), all services are built.
+                An empty list means that nothing will be built.
             build_arguments: Set build-time variables for services. For example
                  `build_args={"PY_VERSION": "3.7.8", "UBUNTU_VERSION": "20.04"}`.
             cache: Set to `False` if you don't want to use the cache to build your images
@@ -49,7 +50,11 @@ class ComposeCLI(DockerCLICaller):
         full_cmd.add_flag("--pull", pull)
         full_cmd.add_flag("--quiet", quiet)
         full_cmd.add_simple_arg("--ssh", ssh)
-        full_cmd += services
+
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += services
         run(full_cmd, capture_stdout=False)
 
     def config(self, return_json: bool = False) -> Union[ComposeConfig, Dict[str, Any]]:
@@ -83,7 +88,7 @@ class ComposeCLI(DockerCLICaller):
 
     def create(
         self,
-        services: Union[str, List[str]] = [],
+        services: Union[str, List[str], None] = None,
         build: bool = False,
         force_recreate: bool = False,
         no_build: bool = False,
@@ -92,6 +97,12 @@ class ComposeCLI(DockerCLICaller):
         """Creates containers for a service.
 
         # Arguments
+            services: The name of the services for which the containers will
+                be created. The default `None` means that the containers for all
+                services will be created. A single string means we will create the
+                container for a single service. A list of string means we will create
+                the containers for each service in the list. An empty list means nothing
+                will be created, the function call is then a no-op.
             build: Build images before starting containers.
             force_recreate: Recreate containers even if their configuration and
                 image haven't changed.
@@ -104,7 +115,10 @@ class ComposeCLI(DockerCLICaller):
         full_cmd.add_flag("--force-recreate", force_recreate)
         full_cmd.add_flag("--no-build", no_build)
         full_cmd.add_flag("--no-recreate", no_recreate)
-        full_cmd += to_list(services)
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += to_list(services)
         run(full_cmd, capture_stdout=False)
 
     def down(
@@ -164,7 +178,7 @@ class ComposeCLI(DockerCLICaller):
             index: The index of the container to execute the command in (default 1) if there are multiple containers for this service.
             tty: If `True`, allocate a pseudo-TTY. Use `False` to get the output of the command.
             privileged: If `True`, run the command in privileged mode.
-            user: The user name to use inside the container.
+            user: The username to use inside the container.
             workdir: The working directory inside the container.
         """
         full_cmd = self.docker_compose_cmd + ["exec"]
@@ -184,18 +198,25 @@ class ComposeCLI(DockerCLICaller):
         else:
             return run(full_cmd)
 
-    def kill(self, services: Union[str, List[str]] = [], signal: Optional[str] = None):
+    def kill(
+        self, services: Union[str, List[str]] = None, signal: Optional[str] = None
+    ):
         """Kills the container(s) of a service
 
         # Arguments
-            services: One or more service(s) to kill
+            services: One or more service(s) to kill. The default (`None`) is to kill all services.
+                A string means the call will kill one single service. A list of service names can
+                be provided to kill multiple services in one function call.
+                An empty list means that no services are going to be killed, the function is then
+                a no-op.
             signal: the signal to send to the container. Default is `"SIGKILL"`
         """
-        services = to_list(services)
-
         full_cmd = self.docker_compose_cmd + ["kill"]
         full_cmd.add_simple_arg("--signal", signal)
-        full_cmd += services
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += to_list(services)
         run(full_cmd)
 
     def logs(
@@ -223,7 +244,7 @@ class ComposeCLI(DockerCLICaller):
             since: Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
             until: Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
             stream: Similar to the `stream` argument of `docker.run()`.
-                This function will then returns and iterator that will yield a
+                This function will then return and iterator that will yield a
                 tuple `(source, content)` with `source` being `"stderr"` or
                 `"stdout"`. `content` is the content of the line as bytes.
                 Take a look at [the user guide](https://gabrieldemarmiesse.github.io/python-on-whales/user_guide/docker_run/#stream-the-output)
@@ -247,10 +268,21 @@ class ComposeCLI(DockerCLICaller):
         else:
             return "".join(x[1].decode() for x in iterator)
 
-    def pause(self, services: Union[str, List[str]] = []):
-        """Pause one or more services"""
+    def pause(self, services: Union[str, List[str], None] = None):
+        """Pause one or more services
+
+        # Arguments
+            services: `None` (the default) means pause all containers of all
+                compose services. A string means that the call will pause the container
+                of a specific service. A list of string means the call will pause
+                the containers of all the services specified. So if an empty list
+                is provided, then this function call is a no-op.
+        """
         full_cmd = self.docker_compose_cmd + ["pause"]
-        full_cmd += to_list(services)
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += to_list(services)
         run(full_cmd)
 
     def port(self):
@@ -276,7 +308,7 @@ class ComposeCLI(DockerCLICaller):
 
     def pull(
         self,
-        services: List[str] = [],
+        services: Optional[List[str]] = None,
         ignore_pull_failures: bool = False,
         include_deps: bool = False,
     ):
@@ -284,8 +316,9 @@ class ComposeCLI(DockerCLICaller):
 
         # Arguments
             services: The list of services to select. Only the images of those
-                services will be pulled. If no services are specified (the default
+                services will be pulled. If no services are specified (`None`) (the default
                 behavior) all images of all services are pulled.
+                If an empty list is provided, then the function call is a no-op.
             ignore_pull_failures: Pull what it can and ignores images with pull failures
             include_deps: Also pull services declared as dependencies
 
@@ -293,30 +326,39 @@ class ComposeCLI(DockerCLICaller):
         full_cmd = self.docker_compose_cmd + ["pull"]
         full_cmd.add_flag("--ignore-pull-failures", ignore_pull_failures)
         full_cmd.add_flag("--include-deps", include_deps)
-        full_cmd += services
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += services
         run(full_cmd)
 
-    def push(self, services: List[str] = []):
+    def push(self, services: Optional[List[str]] = None):
         """Push service images
 
         # Arguments
             services: The list of services to select. Only the images of those
-                services will be pushed. If no services are specified (the default
+                services will be pushed. If no services are specified (`None`, the default
                 behavior) all images of all services are pushed.
+                If an empty list is provided, then the function call is a no-op.
         """
         full_cmd = self.docker_compose_cmd + ["push"]
-        full_cmd += services
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += services
         run(full_cmd)
 
     def restart(
         self,
-        services: Union[str, List[str]] = [],
+        services: Union[str, List[str], None] = None,
         timeout: Union[int, timedelta, None] = None,
     ):
         """Restart containers
 
         # Arguments
-            services: The names of one or more services to restart (str or list of str)
+            services: The names of one or more services to restart (str or list of str).
+                If the argument is not specified, `services` is `None` and all services are restarted.
+                If `services` is an empty list, then the function call is a no-op.
             timeout: The shutdown timeout (`int` are interpreted as seconds).
                 `None` means the CLI default value (10s).
                 See [the docker stop docs](https://docs.docker.com/engine/reference/commandline/stop/)
@@ -328,12 +370,15 @@ class ComposeCLI(DockerCLICaller):
             timeout = int(timeout.total_seconds())
 
         full_cmd.add_simple_arg("--timeout", timeout)
-        full_cmd += to_list(services)
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += to_list(services)
         run(full_cmd)
 
     def rm(
         self,
-        services: Union[str, List[str]] = [],
+        services: Union[str, List[str], None] = None,
         stop: bool = False,
         volumes: bool = False,
     ):
@@ -346,14 +391,19 @@ class ComposeCLI(DockerCLICaller):
         Any data which is not in a volume will be lost.
 
         # Arguments
-            services: The names of one or more services to remove (str or list of str)
+            services: The names of one or more services to remove (str or list of str).
+                If `None` (the default) then all services are removed.
+                If an empty list is provided, this function call is a no-op.
             stop: Stop the containers, if required, before removing
             volumes: Remove any anonymous volumes attached to containers
         """
         full_cmd = self.docker_compose_cmd + ["rm", "--force"]
         full_cmd.add_flag("--stop", stop)
         full_cmd.add_flag("--volumes", volumes)
-        full_cmd += to_list(services)
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += to_list(services)
         run(full_cmd)
 
     def run(
@@ -454,25 +504,32 @@ class ComposeCLI(DockerCLICaller):
             else:
                 return result
 
-    def start(self, services: Union[str, List[str]] = []):
+    def start(self, services: Union[str, List[str], None] = None):
         """Start the specified services.
 
         # Arguments
-            services: The names of one or more services to start
+            services: The names of one or more services to start.
+                If `None` (the default), it means all services will start.
+                If an empty list is provided, this function call is a no-op.
         """
         full_cmd = self.docker_compose_cmd + ["start"]
-        full_cmd += to_list(services)
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += to_list(services)
         run(full_cmd)
 
     def stop(
         self,
-        services: Union[str, List[str]] = [],
+        services: Union[str, List[str], None] = None,
         timeout: Union[int, timedelta, None] = None,
     ):
         """Stop services
 
         # Arguments
-            services: The names of one or more services to stop (str or list of str)
+            services: The names of one or more services to stop (str or list of str).
+                If `None` (the default), it means all services will stop.
+                If an empty list is provided, this function call is a no-op.
             timeout: Number of seconds or timedelta (will be converted to seconds).
                 Specify a shutdown timeout. Default is 10s.
         """
@@ -481,22 +538,35 @@ class ComposeCLI(DockerCLICaller):
 
         full_cmd = self.docker_compose_cmd + ["stop"]
         full_cmd.add_simple_arg("--timeout", timeout)
-        full_cmd += to_list(services)
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += to_list(services)
         run(full_cmd)
 
     def top(self):
         """Not yet implemented"""
         raise NotImplementedError
 
-    def unpause(self, services: Union[str, List[str]] = []):
-        """Unpause one or more services"""
+    def unpause(self, services: Union[str, List[str], None] = None):
+        """Unpause one or more services
+
+        # Arguments
+            services: One or more service to unpause.
+                If `None` (the default), all services are unpaused.
+                If services is an empty list, the function call does nothing,
+                it's a no-op.
+        """
         full_cmd = self.docker_compose_cmd + ["unpause"]
-        full_cmd += to_list(services)
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += to_list(services)
         run(full_cmd)
 
     def up(
         self,
-        services: List[str] = [],
+        services: Optional[List[str]] = None,
         build: bool = False,
         detach: bool = False,
         abort_on_container_exit: bool = False,
@@ -513,8 +583,9 @@ class ComposeCLI(DockerCLICaller):
         Reading the logs of the containers is not yet implemented.
 
         # Arguments
-            services: The services to start. If empty (default), all services are
-                started.
+            services: The services to start. If `None` (default), all services are
+                started. If an empty list is provided, the function call does nothing, it's
+                a no-op.
             build: If `True`, build the docker images before starting the containers
                 even if a docker image with this name already exists.
                 If `False` (the default), build only the docker images that do not already
@@ -553,7 +624,10 @@ class ComposeCLI(DockerCLICaller):
         full_cmd.add_flag("--no-log-prefix", not log_prefix)
         full_cmd.add_flag("--no-start", not start)
 
-        full_cmd += services
+        if services == []:
+            return
+        elif services is not None:
+            full_cmd += services
         run(full_cmd, capture_stdout=False)
 
     def version(self) -> str:

--- a/python_on_whales/components/config/cli_wrapper.py
+++ b/python_on_whales/components/config/cli_wrapper.py
@@ -144,7 +144,10 @@ class ConfigCLI(DockerCLICaller):
         # Arguments
             x: One or a list of configs. Valid values are the id of the config or
                 a `python_on_whales.Config` object.
+                An empty list means the function call does nothing.
         """
         full_cmd = self.docker_cmd + ["config", "rm"]
+        if x == []:
+            return
         full_cmd += to_list(x)
         run(full_cmd)

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -897,7 +897,7 @@ class ContainerCLI(DockerCLICaller):
 
         """
         containers = to_list(containers)
-        if not containers:
+        if containers == []:
             # nothing to do
             return
         full_cmd = self.docker_cmd + ["container", "kill"]
@@ -1014,7 +1014,7 @@ class ContainerCLI(DockerCLICaller):
             `python_on_whales.exceptions.NoSuchContainer` if the container does not exists.
         """
         containers = to_list(containers)
-        if not containers:
+        if containers == []:
             # nothing to do
             return
         full_cmd = self.docker_cmd + ["pause"]
@@ -1551,7 +1551,7 @@ class ContainerCLI(DockerCLICaller):
             containers: One or a list of containers.
         """
         containers = to_list(containers)
-        if not containers:
+        if containers == []:
             # nothing to do
             return
         if attach and len(containers) > 1:
@@ -1631,7 +1631,7 @@ class ContainerCLI(DockerCLICaller):
             `python_on_whales.exceptions.NoSuchContainer` if the container does not exists.
         """
         containers = to_list(containers)
-        if not containers:
+        if containers == []:
             # nothing to do
             return
         full_cmd = self.docker_cmd + ["container", "stop"]
@@ -1666,7 +1666,7 @@ class ContainerCLI(DockerCLICaller):
             `python_on_whales.exceptions.NoSuchContainer` if the container does not exists.
         """
         x = to_list(x)
-        if not x:
+        if x == []:
             # nothing to do
             return
         full_cmd = self.docker_cmd + ["container", "unpause"]
@@ -1721,7 +1721,7 @@ class ContainerCLI(DockerCLICaller):
             `python_on_whales.exceptions.NoSuchContainer` if the container does not exists.
         """
         x = to_list(x)
-        if not x:
+        if x == []:
             # nothing to do
             return
         full_cmd = self.docker_cmd + ["container", "update"]

--- a/python_on_whales/components/context/cli_wrapper.py
+++ b/python_on_whales/components/context/cli_wrapper.py
@@ -119,11 +119,13 @@ class ContextCLI(DockerCLICaller):
         """Removes one or more contexts
 
         # Arguments
-            x: One or more contexts
+            x: One or more contexts, empty list means no-op.
             force: Force the removal of this context
         """
         full_cmd = self.docker_cmd + ["context", "remove"]
         full_cmd.add_flag("--force", force)
+        if x == []:
+            return
         full_cmd += to_list(x)
         run(full_cmd)
 

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -502,7 +502,7 @@ class ImageCLI(DockerCLICaller):
         # this is just to raise a correct exception if the images don't exist
         self.inspect(x)
 
-        if len(x) == 0:
+        if x == []:
             return
         elif len(x) == 1:
             self._push_single_tag(x[0], quiet=quiet)
@@ -545,6 +545,8 @@ class ImageCLI(DockerCLICaller):
         full_cmd = self.docker_cmd + ["image", "rm"]
         full_cmd.add_flag("--force", force)
         full_cmd.add_flag("--no-prune", not prune)
+        if x == []:
+            return
         for image in to_list(x):
             full_cmd.append(image)
 

--- a/python_on_whales/components/node/cli_wrapper.py
+++ b/python_on_whales/components/node/cli_wrapper.py
@@ -108,6 +108,8 @@ class NodeCLI(DockerCLICaller):
             x: One or a list of nodes.
         """
         full_cmd = self.docker_cmd + ["node", "demote"]
+        if x == []:
+            return
         full_cmd += to_list(x)
         run(full_cmd)
 
@@ -151,11 +153,13 @@ class NodeCLI(DockerCLICaller):
             x: One or a list of nodes.
         """
         full_cmd = self.docker_cmd + ["node", "promote"]
+        if x == []:
+            return
         full_cmd += to_list(x)
         run(full_cmd)
 
     def ps(
-        self, x: Union[ValidNode, List[ValidNode]] = []
+        self, x: Union[ValidNode, List[ValidNode], None] = None
     ) -> List[python_on_whales.components.task.cli_wrapper.Task]:
         """Returns the list of swarm tasks running on one or more nodes.
 
@@ -170,12 +174,21 @@ class NodeCLI(DockerCLICaller):
         # Arguments
             x: One or more nodes (can be id, name or `python_on_whales.Node` object.).
                 If the argument is not provided, it defaults to the current node.
+                An empty list means an empty list will also be returned.
 
         # Returns
             `List[python_on_whales.Task]`
         """
+        if x == []:
+            return []
+        elif x is None:
+            # this is the default, on the command line, nothing is provided, and then
+            # it automatically defaults to the current node.
+            command_args = []
+        else:
+            command_args = to_list(x)
         full_cmd = (
-            self.docker_cmd + ["node", "ps", "--quiet", "--no-trunc"] + to_list(x)
+            self.docker_cmd + ["node", "ps", "--quiet", "--no-trunc"] + command_args
         )
         ids = run(full_cmd).splitlines()
         return [
@@ -195,6 +208,8 @@ class NodeCLI(DockerCLICaller):
         """
         full_cmd = self.docker_cmd + ["node", "remove"]
         full_cmd.add_flag("--force", force)
+        if x == []:
+            return
         full_cmd += to_list(x)
         run(full_cmd)
 

--- a/python_on_whales/components/plugin/cli_wrapper.py
+++ b/python_on_whales/components/plugin/cli_wrapper.py
@@ -239,6 +239,8 @@ class PluginCLI(DockerCLICaller):
         """
         full_cmd = self.docker_cmd + ["plugin", "remove"]
         full_cmd.add_flag("--force", force)
+        if x == []:
+            return
         full_cmd += to_list(x)
         run(full_cmd)
 

--- a/python_on_whales/components/secret/cli_wrapper.py
+++ b/python_on_whales/components/secret/cli_wrapper.py
@@ -93,5 +93,7 @@ class SecretCLI(DockerCLICaller):
             x: One or more secrets.
                 Name, ids or `python_on_whales.Secret` objects are valid inputs.
         """
+        if x == []:
+            return
         full_cmd = self.docker_cmd + ["secret", "remove"] + to_list(x)
         run(full_cmd)

--- a/python_on_whales/components/service/cli_wrapper.py
+++ b/python_on_whales/components/service/cli_wrapper.py
@@ -389,9 +389,6 @@ class ServiceCLI(DockerCLICaller):
             `python_on_whales.exceptions.NoSuchService` if one of the services
             doesn't exist.
         """
-        if x == []:
-            return []
-
         full_cmd = (
             self.docker_cmd + ["service", "ps", "--quiet", "--no-trunc"] + to_list(x)
         )
@@ -411,9 +408,12 @@ class ServiceCLI(DockerCLICaller):
 
         # Raises
             `python_on_whales.exceptions.NoSuchService` if one of the services
-            doesn't exists.
+            doesn't exist.
         """
         full_cmd = self.docker_cmd + ["service", "remove"]
+
+        if services == []:
+            return
 
         for service in to_list(services):
             full_cmd.append(service)

--- a/python_on_whales/components/service/cli_wrapper.py
+++ b/python_on_whales/components/service/cli_wrapper.py
@@ -387,8 +387,11 @@ class ServiceCLI(DockerCLICaller):
 
         # Raises
             `python_on_whales.exceptions.NoSuchService` if one of the services
-            doesn't exists.
+            doesn't exist.
         """
+        if x == []:
+            return []
+
         full_cmd = (
             self.docker_cmd + ["service", "ps", "--quiet", "--no-trunc"] + to_list(x)
         )

--- a/python_on_whales/components/stack/cli_wrapper.py
+++ b/python_on_whales/components/stack/cli_wrapper.py
@@ -132,9 +132,11 @@ class StackCLI(DockerCLICaller):
         """Removes one or more stacks.
 
         # Arguments
-            x: One or more stacks
+            x: One or more stacks, empty list means nothing will be done.
 
         """
+        if x == []:
+            return
         full_cmd = self.docker_cmd + ["stack", "remove"] + to_list(x)
         run(full_cmd)
 

--- a/python_on_whales/components/stack/cli_wrapper.py
+++ b/python_on_whales/components/stack/cli_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import python_on_whales.components.service.cli_wrapper
 import python_on_whales.components.task.cli_wrapper
@@ -17,8 +17,11 @@ class Stack:
     def __str__(self):
         return self.name
 
-    def __eq__(self, other: Stack):
-        return self.client_config == other.client_config and self.name == other.name
+    def __eq__(self, other: Any):
+        if isinstance(other, Stack):
+            return self.client_config == other.client_config and self.name == other.name
+        else:
+            return False
 
     def __repr__(self):
         return f"python_on_whales.Stack(name='{self.name}')"

--- a/python_on_whales/components/volume/cli_wrapper.py
+++ b/python_on_whales/components/volume/cli_wrapper.py
@@ -211,11 +211,13 @@ class VolumeCLI(DockerCLICaller):
         """Removes one or more volumes
 
         # Arguments
-            x: A volume or a list of volumes.
+            x: A volume or a list of volumes. An empty list as argument means
+                nothing is done.
         """
 
         full_cmd = self.docker_cmd + ["volume", "remove"]
-
+        if x == []:
+            return
         for v in to_list(x):
             full_cmd.append(str(v))
 

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -31,6 +31,47 @@ def mock_KeyboardInterrupt(signum, frame):
     raise KeyboardInterrupt("Time is up")
 
 
+def test_build_empty_list_of_services():
+    previous_images = set(docker.image.list())
+    docker.compose.build([])
+    assert previous_images == set(docker.image.list())
+
+
+def test_create_empty_list_of_services():
+    previous_containers = set(docker.ps(all=True))
+    docker.compose.create([])
+    assert previous_containers == set(docker.ps(all=True))
+
+
+def test_kill_empty_list_of_services():
+    docker.compose.up(["my_service", "busybox", "alpine"], detach=True)
+    time.sleep(1)
+    all_running_containers = set(docker.ps())
+    docker.compose.kill([])
+    assert all_running_containers == set(docker.ps())
+    docker.compose.down(timeout=1)
+
+
+def test_pause_empty_list_of_services():
+    docker.compose.up(["my_service", "busybox", "alpine"], detach=True)
+    time.sleep(1)
+    number_of_paused_containers = len([x for x in docker.ps() if x.state.paused])
+    docker.compose.pause([])
+    assert number_of_paused_containers == len(
+        [x for x in docker.ps() if x.state.paused]
+    )
+    docker.compose.down(timeout=1)
+
+
+def test_remove_empty_list_of_services():
+    docker.compose.up(["my_service", "busybox", "alpine"], detach=True)
+    time.sleep(1)
+    number_of_containers = len(docker.ps())
+    docker.compose.rm([], stop=True)
+    assert number_of_containers == len(docker.ps())
+    docker.compose.down(timeout=1)
+
+
 def test_compose_project_name():
     docker = DockerClient(
         compose_files=[

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -72,6 +72,16 @@ def test_remove_empty_list_of_services():
     docker.compose.down(timeout=1)
 
 
+def test_pull_empty_list_of_services():
+    len_list_of_images = len(docker.image.list())
+    docker.compose.pull([])
+    assert len_list_of_images == len(docker.image.list())
+
+
+def test_push_empty_list_of_services():
+    docker.compose.push([])
+
+
 def test_compose_project_name():
     docker = DockerClient(
         compose_files=[
@@ -237,6 +247,25 @@ def test_docker_compose_restart():
 
     for container in docker.compose.ps():
         assert (datetime.now(pytz.utc) - container.state.started_at) < timedelta(
+            seconds=2
+        )
+
+    docker.compose.down()
+
+
+def test_docker_compose_restart_empty_list_of_services():
+    docker.compose.up(["my_service"], detach=True)
+    time.sleep(2)
+
+    for container in docker.compose.ps():
+        assert (datetime.now(pytz.utc) - container.state.started_at) > timedelta(
+            seconds=2
+        )
+
+    docker.compose.restart([], timeout=1)
+
+    for container in docker.compose.ps():
+        assert (datetime.now(pytz.utc) - container.state.started_at) > timedelta(
             seconds=2
         )
 

--- a/tests/python_on_whales/components/test_config.py
+++ b/tests/python_on_whales/components/test_config.py
@@ -29,3 +29,13 @@ def test_labels_config(tmp_path):
         assert my_conf.spec.name == "my_conf"
         assert docker.config.list(filters=dict(label="dodo=dada")) == [my_conf]
         assert docker.config.list(filters=dict(label="dodo=dadu")) == []
+
+
+@pytest.mark.usefixtures("swarm_mode")
+def test_remove_empty_config_list(tmp_path):
+    config_file = tmp_path / "config.conf"
+    config_file.write_text("hello world")
+    with docker.config.create("my_conf", config_file) as my_conf:
+        assert docker.config.list() == [my_conf]
+        docker.config.remove([])
+        assert docker.config.list() == [my_conf]

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -500,7 +500,10 @@ def test_stop_nothing():
 
 
 def test_kill_nothing():
-    docker.container.stop([])
+    with docker.run("ubuntu", ["sleep", "infinity"], detach=True, remove=True):
+        set_of_containers = set(docker.ps())
+        docker.container.kill([])
+        assert set_of_containers == set(docker.ps())
 
 
 def test_exec_env():

--- a/tests/python_on_whales/components/test_context.py
+++ b/tests/python_on_whales/components/test_context.py
@@ -26,3 +26,9 @@ def test_list_contexts():
 
 def test_use_context():
     docker.context.use("default")
+
+
+def test_remove_empty_context_list():
+    all_contexts = set(docker.context.list())
+    docker.context.remove([])
+    assert all_contexts == set(docker.context.list())

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -176,6 +176,13 @@ def test_prune():
         docker.image.inspect("busybox")
 
 
+def test_remove_nothing():
+    with docker.pull("hello-world"):
+        all_images = set(docker.image.list())
+        docker.image.remove([])
+        assert all_images == set(docker.image.list())
+
+
 @pytest.mark.parametrize(
     "docker_function", [docker.image.inspect, docker.image.remove, docker.push]
 )

--- a/tests/python_on_whales/components/test_network.py
+++ b/tests/python_on_whales/components/test_network.py
@@ -53,4 +53,6 @@ def test_network_connect_disconnect():
 
 
 def test_remove_nothing():
+    all_neworks = set(docker.network.list())
     docker.network.remove([])
+    assert all_neworks == set(docker.network.list())

--- a/tests/python_on_whales/components/test_node.py
+++ b/tests/python_on_whales/components/test_node.py
@@ -37,3 +37,10 @@ def test_tasks():
     assert len(tasks) > 0
     assert tasks[0].desired_state == "running"
     docker.service.remove(service)
+
+
+@pytest.mark.usefixtures("swarm_mode")
+def test_list_tasks_node():
+    with docker.service.create("busybox", ["sleep", "infinity"]) as my_service:
+        assert docker.node.ps([]) == []
+        assert set(docker.node.ps()) == set(docker.service.ps(my_service))

--- a/tests/python_on_whales/components/test_plugin.py
+++ b/tests/python_on_whales/components/test_plugin.py
@@ -34,3 +34,11 @@ def test_plugin_upgrade():
     with docker.plugin.install(test_plugin_name) as my_plugin:
         my_plugin.disable()
         my_plugin.upgrade()
+
+
+def test_remove_empty_plugin_list():
+    with docker.plugin.install(test_plugin_name) as my_plugin:
+        plugins_set = set(docker.plugin.list())
+        assert my_plugin in plugins_set
+        docker.plugin.remove([])
+        assert set(docker.plugin.list()) == plugins_set

--- a/tests/python_on_whales/components/test_service.py
+++ b/tests/python_on_whales/components/test_service.py
@@ -49,6 +49,17 @@ def test_get_list_of_services_no_services():
 
 
 @pytest.mark.usefixtures("swarm_mode")
+def test_remove_empty_services_list():
+    with docker.service.create(
+        "busybox", ["sh", "-c", "echo dodo && sleep infinity"]
+    ) as my_service:
+        assert my_service in docker.service.list()
+        set_services = set(docker.service.list())
+        docker.service.remove([])
+        assert set(docker.service.list()) == set_services
+
+
+@pytest.mark.usefixtures("swarm_mode")
 def test_service_scale():
     service = docker.service.create("busybox", ["sleep", "infinity"])
     service.scale(3)

--- a/tests/python_on_whales/components/test_stack.py
+++ b/tests/python_on_whales/components/test_stack.py
@@ -29,6 +29,12 @@ def test_services_inspect():
     assert "name='some_stack'" in repr(docker.stack.list())
 
 
+@pytest.mark.usefixtures("with_test_stack")
+def test_remove_empty_stack_list():
+    docker.stack.remove([])
+    assert docker.stack.list() != []
+
+
 def test_stack_ps_and_services(with_test_stack):
 
     all_services = docker.service.list()

--- a/tests/python_on_whales/components/test_volume.py
+++ b/tests/python_on_whales/components/test_volume.py
@@ -203,7 +203,7 @@ def test_prune():
     volume = docker.volume.create("test-volume")
     assert volume in docker.volume.list()
 
-    # volume not pruned because it is does not have label "dne"
+    # volume not pruned because it does not have label "dne"
     docker.volume.prune(filters={"label": "dne"})
     assert volume in docker.volume.list()
 
@@ -212,3 +212,11 @@ def test_prune():
     # volume pruned
     docker.volume.prune()
     assert volume not in docker.volume.list()
+
+
+def test_volume_remove_empty_list():
+    with docker.volume.create() as my_volume:
+        assert my_volume in docker.volume.list()
+        all_volumes = set(docker.volume.list())
+        docker.volume.remove([])
+        assert all_volumes == set(docker.volume.list())


### PR DESCRIPTION
Fixes https://github.com/gabrieldemarmiesse/python-on-whales/issues/174

when calling a function doing stuff to a list of containers/images/volumes/services/... an empty list should mean do nothing.
In the case of some functions (e.g. docker.compose.pause()) `None` is the default and means execute on every service.
