### PR TITLE
Add fields 'platforms' and  'status' to Builder.

### DIFF
--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -60,6 +60,10 @@ class Builder(ReloadableObject):
     def driver(self) -> str:
         return self._get_inspect_result().driver
 
+    @property
+    def platforms(self) -> List[str]:
+        return self._get_inspect_result().platforms
+
     def __repr__(self):
         return f"python_on_whales.Builder(name='{self.name}', driver='{self.driver}')"
 
@@ -444,11 +448,9 @@ class BuildxCLI(DockerCLICaller):
 
     def inspect(self, x: Optional[str] = None) -> Builder:
         """Returns a builder instance from the name.
-
         # Arguments
             x: If `None` (the default), returns the current builder. If a string is provided,
                 the builder that has this name is returned.
-
         # Returns
             A `python_on_whales.Builder` object.
         """

--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -452,9 +452,11 @@ class BuildxCLI(DockerCLICaller):
 
     def inspect(self, x: Optional[str] = None) -> Builder:
         """Returns a builder instance from the name.
+
         # Arguments
             x: If `None` (the default), returns the current builder. If a string is provided,
                 the builder that has this name is returned.
+
         # Returns
             A `python_on_whales.Builder` object.
         """

--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -61,6 +61,10 @@ class Builder(ReloadableObject):
         return self._get_inspect_result().driver
 
     @property
+    def status(self) -> str:
+        return self._get_inspect_result().status
+
+    @property
     def platforms(self) -> List[str]:
         return self._get_inspect_result().platforms
 

--- a/python_on_whales/components/buildx/models.py
+++ b/python_on_whales/components/buildx/models.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import List
 

--- a/python_on_whales/components/buildx/models.py
+++ b/python_on_whales/components/buildx/models.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
-
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import List
 
 
 @dataclass
 class BuilderInspectResult:
     name: str
     driver: str
+    platforms: List[str] = field(default_factory=lambda: [])
 
     @classmethod
     def from_str(cls, string: str) -> BuilderInspectResult:
+
         string = string.strip()
         result_dict = {}
         for line in string.splitlines():
@@ -17,5 +19,9 @@ class BuilderInspectResult:
                 result_dict["name"] = line.split(":")[1].strip()
             if line.startswith("Driver:"):
                 result_dict["driver"] = line.split(":")[1].strip()
+            if line.startswith("Platforms:"):
+                platforms = line.split(":")[1].strip()
+                if platforms:
+                    result_dict["platforms"] = platforms.split(", ")
 
         return cls(**result_dict)

--- a/python_on_whales/components/buildx/models.py
+++ b/python_on_whales/components/buildx/models.py
@@ -7,6 +7,7 @@ from typing import List
 class BuilderInspectResult:
     name: str
     driver: str
+    status: str
     platforms: List[str] = field(default_factory=lambda: [])
 
     @classmethod
@@ -19,6 +20,8 @@ class BuilderInspectResult:
                 result_dict["name"] = line.split(":")[1].strip()
             if line.startswith("Driver:"):
                 result_dict["driver"] = line.split(":")[1].strip()
+            if line.startswith("Status:"):
+                result_dict["status"] = line.split(":")[1].strip()
             if line.startswith("Platforms:"):
                 platforms = line.split(":")[1].strip()
                 if platforms:

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -367,8 +367,8 @@ Driver: docker-container
 Nodes:
 Name:      blissful_swartz0
 Endpoint:  unix:///var/run/docker.sock
-Status:    inactive
-Platforms:  linux/amd64, linux/arm64
+Status:    running
+Platforms: linux/amd64, linux/arm64
 """
 
 
@@ -376,13 +376,15 @@ def test_builder_inspect_result_from_string():
     a = BuilderInspectResult.from_str(some_builder_info)
     assert a.name == "blissful_swartz"
     assert a.driver == "docker-container"
+    assert a.status == "inactive"
     assert a.platforms == []
 
 
-def test_builder_inspect_result__platforms_from_string():
+def test_builder_inspect_result_platforms_from_string():
     a = BuilderInspectResult.from_str(some_builder_info_with_platforms)
     assert a.name == "blissful_swartz"
     assert a.driver == "docker-container"
+    assert a.status == "running"
     assert a.platforms == ["linux/amd64", "linux/arm64"]
 
 

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -360,11 +360,30 @@ Status:    inactive
 Platforms:
 """
 
+some_builder_info_with_platforms = """
+Name:   blissful_swartz
+Driver: docker-container
+
+Nodes:
+Name:      blissful_swartz0
+Endpoint:  unix:///var/run/docker.sock
+Status:    inactive
+Platforms:  linux/amd64, linux/arm64
+"""
+
 
 def test_builder_inspect_result_from_string():
     a = BuilderInspectResult.from_str(some_builder_info)
     assert a.name == "blissful_swartz"
     assert a.driver == "docker-container"
+    assert a.platforms == []
+
+
+def test_builder_inspect_result__platforms_from_string():
+    a = BuilderInspectResult.from_str(some_builder_info_with_platforms)
+    assert a.name == "blissful_swartz"
+    assert a.driver == "docker-container"
+    assert a.platforms == ["linux/amd64", "linux/arm64"]
 
 
 bake_test_dir = PROJECT_ROOT / "tests/python_on_whales/components/bake_tests"


### PR DESCRIPTION
Consider the following example output:
```
$ docker buildx inspect default
Name:   default
Driver: docker

Nodes:
Name:      default
Endpoint:  default
Status:    running
Platforms: linux/amd64, linux/arm64
```
I am using _python_on_whales_ on a project and needed to access the values of fields _status_ and _platforms_.
However, I was only able to access the values of fields _name_ and _driver_.

With the proposed changes, the following is now possible:
```
>>> from python_on_whales import docker
>>> builder = docker.buildx.inspect('default')
>>> builder.platforms
['linux/amd64', 'linux/arm64']
>>> builder.status
'running'
```
In case no platform data is provided the field _platforms_ assumes value ```[]``` .

Updated unit tests to consider the proposed changes. 