### PR TITLE
Implemented "attach" command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Use the right tool for the right job 🙂
 | buildx  | 10/11 | ![92%](https://progress-bar.dev/92) |
 | compose  | 18/23 | ![73%](https://progress-bar.dev/78) |
 | config  | 4/4 | ![50%](https://progress-bar.dev/100) |
-| container | 22/24 | ![50%](https://progress-bar.dev/91) |
+| container | 23/24 | ![50%](https://progress-bar.dev/91) |
 | context  | 4/6 | ![50%](https://progress-bar.dev/67) |
 | image  | 12/13 | ![50%](https://progress-bar.dev/92) |
 | manifest  | 0/4 | ![50%](https://progress-bar.dev/0) |

--- a/docs/template/docker_client.md
+++ b/docs/template/docker_client.md
@@ -26,6 +26,7 @@
 
 They're actually aliases
 
+* [`docker.attach`](sub-commands/container.md#attach)
 * [`docker.build`](sub-commands/buildx.md#build)
 * [`docker.commit`](sub-commands/container.md#commit)
 * [`docker.copy`](sub-commands/container.md#copy)

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -382,7 +382,7 @@ class ContainerCLI(DockerCLICaller):
         # Arguments
             container: The running container to attach to
             detach_keys: Override the key sequence for detaching a container
-            no_stdin: Do not attach STDIN
+            stdin: Attach STDIN
             sig_proxy: Proxy all received signals to the process (default true)
 
         # Raises

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -372,7 +372,7 @@ class ContainerCLI(DockerCLICaller):
         self,
         container: ValidContainer,
         detach_keys: Optional[str] = None,
-        not stdin: bool = True,
+        stdin: bool = True,
         sig_proxy: bool = True,
     ) -> None:
         """Attach local standard input, output, and error streams to a running container

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -178,7 +178,7 @@ class Container(ReloadableObjectFromJson):
     def attach(
         self,
         detach_keys: Optional[str] = None,
-        no_stdin: bool = False,
+        stdin: bool = True,
         sig_proxy: bool = True,
     ) -> None:
         """Attach local standard input, output, and error streams to a running container.

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -372,7 +372,7 @@ class ContainerCLI(DockerCLICaller):
         self,
         container: ValidContainer,
         detach_keys: Optional[str] = None,
-        no_stdin: bool = False,
+        not stdin: bool = True,
         sig_proxy: bool = True,
     ) -> None:
         """Attach local standard input, output, and error streams to a running container

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -180,7 +180,7 @@ class Container(ReloadableObjectFromJson):
         detach_keys: Optional[str] = None,
         no_stdin: bool = False,
         sig_proxy: bool = True,
-    ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
+    ) -> None:
         """Attach local standard input, output, and error streams to a running container.
 
         Alias: `docker.attach(...)`
@@ -188,9 +188,7 @@ class Container(ReloadableObjectFromJson):
         See the [`docker.container.attach`](../sub-commands/container.md#attach) command for
         information about the arguments.
         """
-        return ContainerCLI(self.client_config).attach(
-            self, detach_keys, no_stdin, sig_proxy
-        )
+        ContainerCLI(self.client_config).attach(self, detach_keys, no_stdin, sig_proxy)
 
     def commit(
         self,
@@ -376,7 +374,7 @@ class ContainerCLI(DockerCLICaller):
         detach_keys: Optional[str] = None,
         no_stdin: bool = False,
         sig_proxy: bool = True,
-    ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
+    ) -> None:
         """Attach local standard input, output, and error streams to a running container
 
         Alias: `docker.attach(...)`
@@ -386,9 +384,6 @@ class ContainerCLI(DockerCLICaller):
             detach_keys: Override the key sequence for detaching a container
             no_stdin: Do not attach STDIN
             sig_proxy: Proxy all received signals to the process (default true)
-
-        # Returns:
-            Optional[str]
 
         # Raises
             `python_on_whales.exceptions.NoSuchContainer` if the container does not exists.
@@ -401,7 +396,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_flag("--sig-proxy", sig_proxy)
         full_cmd.append(container)
 
-        return run(full_cmd, tty=True)
+        run(full_cmd, tty=True)
 
     def commit(
         self,

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -392,7 +392,7 @@ class ContainerCLI(DockerCLICaller):
 
         full_cmd = self.docker_cmd + ["attach"]
         full_cmd.add_simple_arg("--detach-keys", detach_keys)
-        full_cmd.add_flag("--no-stdin", no_stdin)
+        full_cmd.add_flag("--no-stdin", not stdin)
         full_cmd.add_flag("--sig-proxy", sig_proxy)
         full_cmd.append(container)
 

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -396,7 +396,7 @@ class ContainerCLI(DockerCLICaller):
         self.inspect(container)
 
         full_cmd = self.docker_cmd + ["attach"]
-        full_cmd.add_simple_arg('--detach_keys', detach_keys)
+        full_cmd.add_simple_arg('--detach-keys', detach_keys)
         full_cmd.add_flag("--no-stdin", no_stdin)
         full_cmd.add_flag("--sig-proxy", sig_proxy)
         full_cmd.append(container)

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -188,7 +188,7 @@ class Container(ReloadableObjectFromJson):
         See the [`docker.container.attach`](../sub-commands/container.md#attach) command for
         information about the arguments.
         """
-        ContainerCLI(self.client_config).attach(self, detach_keys, no_stdin, sig_proxy)
+        ContainerCLI(self.client_config).attach(self, detach_keys, not stdin, sig_proxy)
 
     def commit(
         self,

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -179,7 +179,7 @@ class Container(ReloadableObjectFromJson):
         self,
         detach_keys: Optional[str] = None,
         no_stdin: bool = False,
-        sig_proxy: bool = True
+        sig_proxy: bool = True,
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
         """Attach local standard input, output, and error streams to a running container.
 
@@ -375,7 +375,7 @@ class ContainerCLI(DockerCLICaller):
         container: ValidContainer,
         detach_keys: Optional[str] = None,
         no_stdin: bool = False,
-        sig_proxy: bool = True
+        sig_proxy: bool = True,
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
         """Attach local standard input, output, and error streams to a running container
 
@@ -396,7 +396,7 @@ class ContainerCLI(DockerCLICaller):
         self.inspect(container)
 
         full_cmd = self.docker_cmd + ["attach"]
-        full_cmd.add_simple_arg('--detach-keys', detach_keys)
+        full_cmd.add_simple_arg("--detach-keys", detach_keys)
         full_cmd.add_flag("--no-stdin", no_stdin)
         full_cmd.add_flag("--sig-proxy", sig_proxy)
         full_cmd.append(container)

--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -152,7 +152,7 @@ class DockerClient(DockerCLICaller):
         self.volume = VolumeCLI(self.client_config)
 
         # aliases
-        self.attach = None
+        self.attach = self.container.attach
         self.build = self.buildx.build
         self.legacy_build = self.image.legacy_build
         self.commit = self.container.commit

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -680,7 +680,7 @@ def test_attach_no_stdin_argument(run_mock: Mock, inspect_mock: Mock) -> None:
 
     test_container_name = "test_dummy_container"
 
-    docker.attach(test_container_name, no_stdin=True)
+    docker.attach(test_container_name, stdin=False)
 
     inspect_mock.assert_called_once_with(test_container_name)
     run_mock.assert_called_once_with(

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -639,14 +639,15 @@ def test_run_detached_interactive():
 @patch("python_on_whales.components.container.cli_wrapper.run")
 def test_attach_default(run_mock: Mock, inspect_mock: Mock) -> None:
 
-    test_container_name = 'test_dummy_container'
+    test_container_name = "test_dummy_container"
 
     docker.attach(test_container_name)
 
     inspect_mock.assert_called_once_with(test_container_name)
     run_mock.assert_called_once_with(
-        docker.client_config.docker_cmd + ['attach', '--sig-proxy', test_container_name],
-        tty=True
+        docker.client_config.docker_cmd
+        + ["attach", "--sig-proxy", test_container_name],
+        tty=True,
     )
 
 
@@ -654,15 +655,22 @@ def test_attach_default(run_mock: Mock, inspect_mock: Mock) -> None:
 @patch("python_on_whales.components.container.cli_wrapper.run")
 def test_attach_detach_keys_argument(run_mock: Mock, inspect_mock: Mock) -> None:
 
-    test_container_name = 'test_dummy_container'
-    test_detach_key = 'dummy'
+    test_container_name = "test_dummy_container"
+    test_detach_key = "dummy"
 
     docker.attach(test_container_name, detach_keys=test_detach_key)
 
     inspect_mock.assert_called_once_with(test_container_name)
     run_mock.assert_called_once_with(
-        docker.client_config.docker_cmd + ['attach', '--detach-keys', test_detach_key, '--sig-proxy', test_container_name],
-        tty=True
+        docker.client_config.docker_cmd
+        + [
+            "attach",
+            "--detach-keys",
+            test_detach_key,
+            "--sig-proxy",
+            test_container_name,
+        ],
+        tty=True,
     )
 
 
@@ -670,14 +678,15 @@ def test_attach_detach_keys_argument(run_mock: Mock, inspect_mock: Mock) -> None
 @patch("python_on_whales.components.container.cli_wrapper.run")
 def test_attach_no_stdin_argument(run_mock: Mock, inspect_mock: Mock) -> None:
 
-    test_container_name = 'test_dummy_container'
+    test_container_name = "test_dummy_container"
 
     docker.attach(test_container_name, no_stdin=True)
 
     inspect_mock.assert_called_once_with(test_container_name)
     run_mock.assert_called_once_with(
-        docker.client_config.docker_cmd + ['attach', '--no-stdin', '--sig-proxy', test_container_name],
-        tty=True
+        docker.client_config.docker_cmd
+        + ["attach", "--no-stdin", "--sig-proxy", test_container_name],
+        tty=True,
     )
 
 
@@ -685,12 +694,11 @@ def test_attach_no_stdin_argument(run_mock: Mock, inspect_mock: Mock) -> None:
 @patch("python_on_whales.components.container.cli_wrapper.run")
 def test_attach_sig_proxy_argument(run_mock: Mock, inspect_mock: Mock) -> None:
 
-    test_container_name = 'test_dummy_container'
+    test_container_name = "test_dummy_container"
 
     docker.attach(test_container_name, sig_proxy=False)
 
     inspect_mock.assert_called_once_with(test_container_name)
     run_mock.assert_called_once_with(
-        docker.client_config.docker_cmd + ['attach', test_container_name],
-        tty=True
+        docker.client_config.docker_cmd + ["attach", test_container_name], tty=True
     )

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -4,6 +4,7 @@ import tempfile
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -16,7 +17,6 @@ from python_on_whales.components.container.models import (
 )
 from python_on_whales.exceptions import DockerException, NoSuchContainer
 from python_on_whales.test_utils import get_all_jsons, random_name
-from unittest.mock import Mock, patch
 
 
 @pytest.mark.parametrize("json_file", get_all_jsons("containers"))


### PR DESCRIPTION
Hello everyone!

I've noticed that the _attach_ command has not yet been implemented and decided to implement it.
With the proposed changes the following is now possible:

```python
from python_on_whales import docker
docker.attach('my_container')  # or docker.container.attach('my_container')

# current shell attaches itself to the container (if existent) shell and 
# all input/output is replicated on all attached shells 
```

Proposed changes also include:
- Support for all CLI arguments;
- Unit tests;
- Documentation update.