### PR TITLE
Fix for Issue #370 - Replace on decode errors rather than surface UnicodeDecodeError

### DIFF
--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -560,4 +560,4 @@ def format_dict_for_buildx(options: Dict[str, str]) -> str:
 
 def stream_buildx_logs(full_cmd: list, env: Dict[str, str] = None) -> Iterator[str]:
     for origin, value in stream_stdout_and_stderr(full_cmd, env=env):
-        yield value.decode(errors='replace')
+        yield value.decode(errors="replace")

--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -560,4 +560,4 @@ def format_dict_for_buildx(options: Dict[str, str]) -> str:
 
 def stream_buildx_logs(full_cmd: list, env: Dict[str, str] = None) -> Iterator[str]:
     for origin, value in stream_stdout_and_stderr(full_cmd, env=env):
-        yield value.decode()
+        yield value.decode(errors='replace')

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -44,6 +44,7 @@ def test_buildx_build_streaming_logs(tmp_path):
     assert output[0] == "#1 [internal] load build definition from Dockerfile\n"
     assert "#6 DONE" in output[-1]
 
+
 @pytest.mark.usefixtures("with_docker_driver")
 def test_buildx_build_streaming_logs_with_decode_error_handling(tmp_path):
     # This will simulate buildx clipping log output in the middle of a UTF-8 character

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -44,6 +44,18 @@ def test_buildx_build_streaming_logs(tmp_path):
     assert output[0] == "#1 [internal] load build definition from Dockerfile\n"
     assert "#6 DONE" in output[-1]
 
+@pytest.mark.usefixtures("with_docker_driver")
+def test_buildx_build_streaming_logs_with_decode_error_handling(tmp_path):
+    # This will simulate buildx clipping log output in the middle of a UTF-8 character
+    bad_encoding_dockerfile = dockerfile_content1 + """
+    RUN printf '\\xE2\\x9E'
+    """
+    (tmp_path / "Dockerfile").write_text(bad_encoding_dockerfile)
+    output = list(docker.buildx.build(tmp_path, cache=False, stream_logs=True))
+    assert output[0] == "#1 [internal] load build definition from Dockerfile\n"
+    assert len([x for x in output if "�" in x]) == 1
+    assert "#7 DONE" in output[-1]
+
 
 @pytest.mark.usefixtures("with_docker_driver")
 def test_buildx_build_load_docker_driver(tmp_path):

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -48,9 +48,12 @@ def test_buildx_build_streaming_logs(tmp_path):
 @pytest.mark.usefixtures("with_docker_driver")
 def test_buildx_build_streaming_logs_with_decode_error_handling(tmp_path):
     # This will simulate buildx clipping log output in the middle of a UTF-8 character
-    bad_encoding_dockerfile = dockerfile_content1 + """
+    bad_encoding_dockerfile = (
+        dockerfile_content1
+        + """
     RUN printf '\\xE2\\x9E'
     """
+    )
     (tmp_path / "Dockerfile").write_text(bad_encoding_dockerfile)
     output = list(docker.buildx.build(tmp_path, cache=False, stream_logs=True))
     assert output[0] == "#1 [internal] load build definition from Dockerfile\n"


### PR DESCRIPTION
Fix for https://github.com/gabrieldemarmiesse/python-on-whales/issues/370

Confirmed that this test, without the `errors='replace'` flag, does throw the UnicodeDecodeError. And now, with the change, will do its best effort and replace with the bad output with `�` as most terminals would do.