### PR TITLE
fix: cannot inspect node with empty leader status

### DIFF
--- a/python_on_whales/components/node/models.py
+++ b/python_on_whales/components/node/models.py
@@ -3,13 +3,15 @@ from typing import Dict, List, Optional
 
 from pydantic import Field
 
-from python_on_whales.utils import DockerCamelModel
+from python_on_whales.utils import DockerCamelModel, all_fields_optional
 
 
+@all_fields_optional
 class NodeVersion(DockerCamelModel):
     index: int
 
 
+@all_fields_optional
 class NodeSpec(DockerCamelModel):
     name: Optional[str]
     labels: Dict[str, str]
@@ -17,49 +19,58 @@ class NodeSpec(DockerCamelModel):
     availability: str
 
 
+@all_fields_optional
 class NodePlatform(DockerCamelModel):
     architecture: str
     os: str = Field(alias="OS")
 
 
+@all_fields_optional
 class NodeNamedResourceSpec(DockerCamelModel):
     kind: str
     value: str
 
 
+@all_fields_optional
 class NodeDiscreteResourceSpec(DockerCamelModel):
     kind: str
     value: int
 
 
+@all_fields_optional
 class NodeGenericResource(DockerCamelModel):
     named_resource_spec: Optional[NodeNamedResourceSpec]
     discrete_resource_spec: Optional[NodeDiscreteResourceSpec]
 
 
+@all_fields_optional
 class NodeResource(DockerCamelModel):
     nano_cpus: int = Field(alias="NanoCPUs")
     memory_bytes: int
     generic_resources: Optional[List[NodeGenericResource]]
 
 
+@all_fields_optional
 class EnginePlugin(DockerCamelModel):
     type: str
     name: str
 
 
+@all_fields_optional
 class NodeEngine(DockerCamelModel):
     engine_version: str
     labels: Optional[Dict[str, str]]
     plugins: List[EnginePlugin]
 
 
+@all_fields_optional
 class NodeTLSInfo(DockerCamelModel):
     trust_root: str
     cert_issuer_subject: str
     cert_issuer_public_key: str
 
 
+@all_fields_optional
 class NodeDescription(DockerCamelModel):
     hostname: str
     platform: NodePlatform
@@ -68,18 +79,21 @@ class NodeDescription(DockerCamelModel):
     tls_info: NodeTLSInfo
 
 
+@all_fields_optional
 class NodeStatus(DockerCamelModel):
     state: str
     message: Optional[str]
     addr: str
 
 
+@all_fields_optional
 class NodeManagerStatus(DockerCamelModel):
     leader: bool
     reachability: str
     addr: str
 
 
+@all_fields_optional
 class NodeInspectResult(DockerCamelModel):
     id: str = Field(alias="ID")
     version: NodeVersion


### PR DESCRIPTION
Fixes a bug where python-on-whales cannot parse CLI output from `docker.node.inspect("****")` if the node does not have a `Leader` value set.

closes #375 