### PR TITLE
Use separate status attributes for ComposeProject model

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -10,6 +10,7 @@ from python_on_whales.client_config import DockerCLICaller
 from python_on_whales.components.compose.models import ComposeConfig, ComposeProject
 from python_on_whales.utils import (
     format_dict_for_cli,
+    parse_ls_status_count,
     run,
     stream_stdout_and_stderr,
     to_list,
@@ -353,11 +354,17 @@ class ComposeCLI(DockerCLICaller):
         full_cmd = self.docker_compose_cmd + ["ls", "--format", "json"]
         full_cmd.add_flag("--all", all)
         full_cmd.add_args_list("--filter", format_dict_for_cli(filters))
+        print("zozo")
+        print(json.loads(run(full_cmd)))
         return [
             ComposeProject(
                 name=proj["Name"],
-                status=proj["Status"].split("(")[0],
-                count=int(proj["Status"].split("(")[1].strip(")")),
+                created=parse_ls_status_count(proj["Status"], "created"),
+                running=parse_ls_status_count(proj["Status"], "running"),
+                restarting=parse_ls_status_count(proj["Status"], "restarting"),
+                exited=parse_ls_status_count(proj["Status"], "exited"),
+                paused=parse_ls_status_count(proj["Status"], "paused"),
+                dead=parse_ls_status_count(proj["Status"], "dead"),
                 config_files=[
                     Path(path)
                     for path in proj.get("ConfigFiles", "").split(",")

--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -354,8 +354,7 @@ class ComposeCLI(DockerCLICaller):
         full_cmd = self.docker_compose_cmd + ["ls", "--format", "json"]
         full_cmd.add_flag("--all", all)
         full_cmd.add_args_list("--filter", format_dict_for_cli(filters))
-        print("zozo")
-        print(json.loads(run(full_cmd)))
+
         return [
             ComposeProject(
                 name=proj["Name"],

--- a/python_on_whales/components/compose/models.py
+++ b/python_on_whales/components/compose/models.py
@@ -122,6 +122,10 @@ class ComposeConfig(BaseModel):
 
 class ComposeProject(BaseModel):
     name: str
-    status: str
-    count: int
+    created: int = None
+    running: int = None
+    restarting: int = None
+    exited: int = None
+    paused: int = None
+    dead: int = None
     config_files: Optional[List[Path]]

--- a/python_on_whales/components/compose/models.py
+++ b/python_on_whales/components/compose/models.py
@@ -122,10 +122,10 @@ class ComposeConfig(BaseModel):
 
 class ComposeProject(BaseModel):
     name: str
-    created: int = None
-    running: int = None
-    restarting: int = None
-    exited: int = None
-    paused: int = None
-    dead: int = None
+    created: int = 0
+    running: int = 0
+    restarting: int = 0
+    exited: int = 0
+    paused: int = 0
+    dead: int = 0
     config_files: Optional[List[Path]]

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -313,3 +313,10 @@ def format_time_for_docker(time_object: Union[datetime, timedelta]) -> str:
         return time_object.strftime("%Y-%m-%dT%H:%M:%S")
     elif isinstance(time_object, timedelta):
         return f"{time_object.total_seconds()}s"
+
+
+def parse_ls_status_count(status_output, status) -> Union[None, str]:
+    try:
+        return status_output.split(status + "(")[1].split(")")[0]
+    except IndexError:
+        return

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -315,8 +315,8 @@ def format_time_for_docker(time_object: Union[datetime, timedelta]) -> str:
         return f"{time_object.total_seconds()}s"
 
 
-def parse_ls_status_count(status_output, status) -> Union[None, str]:
+def parse_ls_status_count(status_output, status) -> int:
     try:
-        return status_output.split(status + "(")[1].split(")")[0]
+        return int(status_output.split(status + "(")[1].split(")")[0])
     except IndexError:
-        return
+        return 0

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -724,26 +724,28 @@ def test_compose_port():
     d.compose.down(timeout=1)
 
 
-def test_compose_ls_project_running():
+def test_compose_ls_project_multiple_statuses():
     d = DockerClient(
         compose_files=[
+            PROJECT_ROOT
+            / "tests/python_on_whales/components/dummy_compose_ends_quickly.yml",
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml",
         ],
         compose_compatibility=True,
         compose_project_name="test_compose_ls",
     )
-    d.compose.up(["busybox"], detach=True)
+    d.compose.up(["alpine", "dodo"], detach=True)
     time.sleep(2)
 
-    projects = d.compose.ls()
+    projects = d.compose.ls(all=True)
     project = [
         proj
         for proj in projects
         if proj.name == d.compose.client_config.compose_project_name
     ][0]
 
-    assert project.status == "running"
-    assert project.count == 1
+    assert project.running == 1
+    assert project.exited == 1
     if project.config_files:
         assert sorted(project.config_files) == sorted(d.client_config.compose_files)
 

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -746,6 +746,7 @@ def test_compose_ls_project_multiple_statuses():
 
     assert project.running == 1
     assert project.exited == 1
+    assert project.paused == 0
     if project.config_files:
         assert sorted(project.config_files) == sorted(d.client_config.compose_files)
 


### PR DESCRIPTION
The `docker compose ls` status attribute may contain multiple container statuses which can break the current status parsing implementation within the `docker.compose.ls()` method. For example, if the docker project that is associated with the docker client has one container running and another exited, the status will be: `running(1), exited(1)`. 

To handle this case, this PR adds each of the possible statuses as an attribute to the `ComposeProject` model. If the status is not found within the `docker compose ls` output, then the status attribute defaults to `0`.