### PR TITLE
Add envs parameter to compose up/config/run

### DIFF
--- a/python_on_whales/client_config.py
+++ b/python_on_whales/client_config.py
@@ -64,6 +64,7 @@ class ClientConfig:
     compose_project_name: Optional[str] = None
     compose_project_directory: Optional[ValidPath] = None
     compose_compatibility: Optional[bool] = None
+    compose_envs: Optional[Dict[str, str]] = None
     client_call: List[str] = field(default_factory=lambda: ["docker"])
     _client_call_with_path: Optional[List[Union[Path, str]]] = None
 
@@ -164,6 +165,10 @@ class DockerCLICaller:
     @property
     def docker_compose_cmd(self) -> Command:
         return self.client_config.docker_compose_cmd
+
+    @property
+    def docker_compose_envs(self) -> Dict[str, str]:
+        return self.client_config.compose_envs or {}
 
 
 class ReloadableObject(DockerCLICaller):

--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -1,6 +1,6 @@
 import base64
 import warnings
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from python_on_whales.client_config import ClientConfig, DockerCLICaller
 from python_on_whales.components.buildx.cli_wrapper import BuildxCLI
@@ -56,6 +56,7 @@ class DockerClient(DockerCLICaller):
             the [documentation for profiles](https://docs.docker.com/compose/profiles/).
         compose_env_file: .env file containing the environments variables to inject
             into the compose project. By default, it uses `./.env`.
+        compose_envs: Environment variables to inject into the docker compose process.
         compose_project_name: The name of the compose project. It will be prefixed to
             networks, volumes and containers created by compose.
         compose_project_directory: Use an alternate working directory. By default, it
@@ -100,6 +101,7 @@ class DockerClient(DockerCLICaller):
         compose_project_name: Optional[str] = None,
         compose_project_directory: Optional[ValidPath] = None,
         compose_compatibility: Optional[bool] = None,
+        compose_envs: Optional[Dict[str, str]] = None,
         client_binary: str = "docker",
         client_call: List[str] = ["docker"],
     ):
@@ -128,6 +130,7 @@ class DockerClient(DockerCLICaller):
                 compose_project_name=compose_project_name,
                 compose_project_directory=compose_project_directory,
                 compose_compatibility=compose_compatibility,
+                compose_envs=compose_envs,
                 client_call=client_call,
             )
         super().__init__(client_config)

--- a/tests/python_on_whales/components/dummy_compose.yml
+++ b/tests/python_on_whales/components/dummy_compose.yml
@@ -15,6 +15,8 @@ services:
   busybox:
     image: busybox:latest
     command: sleep infinity
+    environment:
+     - SOME_VARIABLE=${SOME_VARIABLE_TO_INSERT:-nothing}
   busybox-2-electric-boogaloo:
     image: busybox:latest
     depends_on:


### PR DESCRIPTION
Docker compose allows variable injection from the process environment in addition to a `.env` file. This change will allow user the ability to pass a dictionary of variables to be injected into the compose subprocess.