### PR TITLE
[IMP] "docker compose ps" argument services

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -322,13 +322,18 @@ class ComposeCLI(DockerCLICaller):
         host, port = str(result).split(":")
         return host, int(port)
 
-    def ps(self) -> List[python_on_whales.components.container.cli_wrapper.Container]:
+    def ps(
+        self,
+        services: Optional[List[str]] = None,
+    ) -> List[python_on_whales.components.container.cli_wrapper.Container]:
         """Returns the containers that were created by the current project.
 
         # Returns
             A `List[python_on_whales.Container]`
         """
         full_cmd = self.docker_compose_cmd + ["ps", "--quiet"]
+        if services:
+            full_cmd += services
         result = run(full_cmd)
         ids = result.splitlines()
         # The first line might be a warning for experimental

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -223,6 +223,9 @@ def test_docker_compose_ps():
     containers = docker.compose.ps()
     names = set(x.name for x in containers)
     assert names == {"components_my_service_1", "components_busybox_1"}
+    containers = docker.compose.ps(["my_service"])
+    names = set(x.name for x in containers)
+    assert names == {"components_my_service_1"}
     docker.compose.down()
 
 


### PR DESCRIPTION
Hi everyone!

This is useful if you have many services and you want to choose from which one to list its containers.

From the [docs](https://docs.docker.com/engine/reference/commandline/compose_ps):  ` $ docker compose ps [OPTIONS] [SERVICE...]`




