### PR TITLE
[IMP] docker compose run & up

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -653,6 +653,7 @@ class ComposeCLI(DockerCLICaller):
         scales: Dict[str, int] = {},
         attach_dependencies: bool = False,
         force_recreate: bool = False,
+        recreate: bool = True,
         no_build: bool = False,
         color: bool = True,
         log_prefix: bool = True,
@@ -682,6 +683,8 @@ class ComposeCLI(DockerCLICaller):
             attach_dependencies: Attach to dependent containers.
             force_recreate: Recreate containers even if their configuration and image
                 haven't changed.
+            recreate: Recreate the containers if already exist.
+                `recreate=False` and `force_recreate=True` are incompatible.
             no_build: Don't build an image, even if it's missing.
             color: If `False`, it will produce monochrome output.
             log_prefix: If `False`, will not display the prefix in the logs.
@@ -702,6 +705,7 @@ class ComposeCLI(DockerCLICaller):
             full_cmd.add_simple_arg("--scale", f"{service}={scale}")
         full_cmd.add_flag("--attach-dependencies", attach_dependencies)
         full_cmd.add_flag("--force-recreate", force_recreate)
+        full_cmd.add_flag("--no-recreate", not recreate)
         full_cmd.add_flag("--no-build", no_build)
         full_cmd.add_flag("--no-color", not color)
         full_cmd.add_flag("--no-log-prefix", not log_prefix)

--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -491,7 +491,7 @@ class ComposeCLI(DockerCLICaller):
         detach: bool = False,
         # entrypoint: Optional[List[str]] = None,
         # envs: Dict[str, str] = {},
-        # labels: Dict[str, str] = {},
+        labels: Dict[str, str] = {},
         name: Optional[str] = None,
         tty: bool = True,
         stream: bool = False,
@@ -517,6 +517,7 @@ class ComposeCLI(DockerCLICaller):
             command: The command to execute.
             detach: if `True`, returns immediately with the Container.
                     If `False`, returns the command stdout as string.
+            labels: Add or override labels
             name: Assign a name to the container.
             dependencies: Also start linked services.
             publish: Publish a container's port(s) to the host.
@@ -569,6 +570,7 @@ class ComposeCLI(DockerCLICaller):
         full_cmd.add_flag("--use-aliases", use_aliases)
         full_cmd.add_simple_arg("--user", user)
         full_cmd.add_simple_arg("--workdir", workdir)
+        full_cmd.add_args_list("--label", format_dict_for_cli(labels))
         full_cmd.append(service)
         full_cmd += command
 

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -218,6 +218,16 @@ def test_docker_compose_up_down_some_services():
     docker.compose.down(timeout=1)
 
 
+def test_docker_compose_up_no_recreate():
+    docker.compose.up(["busybox"], detach=True)
+    containers = docker.compose.ps()
+    container_id = containers[0].id
+    docker.compose.up(["busybox"], scales={"busybox": 2}, detach=True, recreate=False)
+    container_ids = set(x.id for x in docker.compose.ps())
+    assert container_id in container_ids
+    docker.compose.down(timeout=1)
+
+
 def test_docker_compose_ps():
     docker.compose.up(["my_service", "busybox"], detach=True)
     containers = docker.compose.ps()

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -469,6 +469,22 @@ def test_compose_run_detach():
     assert container.logs() == "dodo\n"
 
 
+def test_docker_compose_run_labels():
+    container = docker.compose.run(
+        "alpine",
+        ["echo", "dodo"],
+        labels={"traefik.enable": "false", "hello": "world"},
+        detach=True,
+        tty=False,
+    )
+
+    time.sleep(0.1)
+    print(container.config.labels)
+    assert container.config.labels.get("traefik.enable") == "false"
+    assert container.config.labels.get("hello") == "world"
+    docker.compose.down(timeout=1)
+
+
 def test_compose_version():
     assert "Docker Compose version v2" in docker.compose.version()
 


### PR DESCRIPTION
Hi!

### 1st commit

Add or override default labels.
` docker compose run --label="traefik.enable=false" MY_SERVICE ARG` 
[Docs](https://docs.docker.com/engine/reference/commandline/compose_run/)

###  2nd commit

If containers already exist, don't recreate them. 
`docker compose up --no-recreate --scale MY_SERVICE=2`
[Docs](https://docs.docker.com/engine/reference/commandline/compose_up/)
