### PR TITLE
Added support for --remove-orphas docker compose up flag

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -655,6 +655,7 @@ class ComposeCLI(DockerCLICaller):
         force_recreate: bool = False,
         recreate: bool = True,
         no_build: bool = False,
+        remove_orphans: bool = False,
         color: bool = True,
         log_prefix: bool = True,
         start: bool = True,
@@ -686,6 +687,7 @@ class ComposeCLI(DockerCLICaller):
             recreate: Recreate the containers if already exist.
                 `recreate=False` and `force_recreate=True` are incompatible.
             no_build: Don't build an image, even if it's missing.
+            remove_orphans: Remove containers for services not defined in the Compose file.
             color: If `False`, it will produce monochrome output.
             log_prefix: If `False`, will not display the prefix in the logs.
             start: Start the service after creating them.
@@ -710,6 +712,7 @@ class ComposeCLI(DockerCLICaller):
         full_cmd.add_flag("--no-color", not color)
         full_cmd.add_flag("--no-log-prefix", not log_prefix)
         full_cmd.add_flag("--no-start", not start)
+        full_cmd.add_flag("--remove-orphans", remove_orphans)
 
         if services == []:
             return

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -834,4 +834,3 @@ services:
 
     docker.compose.down(timeout=1)
     remove(compose_file)
-

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -784,11 +784,11 @@ def test_compose_ls_project_multiple_statuses():
 
 
 def test_docker_compose_up_remove_orphans():
-    compose_file = tempfile.mktemp(prefix='test_docker_compose_up_remove_orphans_', suffix='.yml')
+    compose_file = tempfile.mktemp(
+        prefix="test_docker_compose_up_remove_orphans_", suffix=".yml"
+    )
     docker = DockerClient(
-        compose_files=[
-            compose_file
-        ],
+        compose_files=[compose_file],
         compose_compatibility=True,
     )
     base_cfg = """version: "3.7"
@@ -803,8 +803,8 @@ services:
 """
 
     # writing the docker compose file with 2 services configured
-    with open(compose_file, 'w') as file:
-        file.write(base_cfg+service_to_remove)
+    with open(compose_file, "w") as file:
+        file.write(base_cfg + service_to_remove)
 
     docker.compose.up(detach=True)
     containers = docker.compose.ps()
@@ -812,7 +812,7 @@ services:
     container_ids = [container.id for container in containers]
 
     # updating the docker compose file to have only 1 service configured
-    with open(compose_file, 'w') as file:
+    with open(compose_file, "w") as file:
         file.write(base_cfg)
 
     docker.compose.up(detach=True)
@@ -823,14 +823,14 @@ services:
     removed_service_container_id = container_ids[0]
 
     # container of the removed service is still running
-    assert len(docker.ps(filters={'id': removed_service_container_id})) == 1
+    assert len(docker.ps(filters={"id": removed_service_container_id})) == 1
 
     # calling with remove_orphans flag
     docker.compose.up(detach=True, remove_orphans=True)
     assert len(docker.compose.ps()) == 1
 
     # container of the removed service was stopped
-    assert len(docker.ps(filters={'id': removed_service_container_id})) == 0
+    assert len(docker.ps(filters={"id": removed_service_container_id})) == 0
 
     docker.compose.down(timeout=1)
     remove(compose_file)

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -787,6 +787,7 @@ def test_docker_compose_up_remove_orphans():
     compose_file = tempfile.mktemp(
         prefix="test_docker_compose_up_remove_orphans_", suffix=".yml"
     )
+    compose_file = Path(compose_file)
     docker = DockerClient(
         compose_files=[compose_file],
         compose_compatibility=True,
@@ -803,8 +804,7 @@ services:
 """
 
     # writing the docker compose file with 2 services configured
-    with open(compose_file, "w") as file:
-        file.write(base_cfg + service_to_remove)
+    compose_file.write_text(base_cfg + service_to_remove)
 
     docker.compose.up(detach=True)
     compose_containers = docker.compose.ps()
@@ -812,8 +812,7 @@ services:
     compose_container_ids = {container.id for container in compose_containers}
 
     # updating the docker compose file to have only 1 service configured
-    with open(compose_file, "w") as file:
-        file.write(base_cfg)
+    compose_file.write_text(base_cfg)
 
     def check_running_containers(expected):
         containers = docker.ps()


### PR DESCRIPTION
Hi,

Would like to add support for this flag also for docker compose up (was implemented already for down).

When you re-run docker compose up on a file from which services were removed you can see messages like this one:
```
time="2022-11-24T14:56:17+02:00" level=warning msg="Found orphan containers ([tmp_busybox2_1]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up."
```

The containers for the services removed from the compose file are still running

There are cases when one would want them shutdown/removed instead, hence adding the support for  `--remove-orphans`