### PR TITLE
fix: Constrain the minimum bound of pydantic.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic
+pydantic>=1.5
 requests
 tqdm
 typer>=0.4.1


### PR DESCRIPTION
Alternatively, I could alter your uses of `Field()` which do not set a `default` value. But the code as-is appears to be incompatible with pydantic before 1.5, where it raises errors like:

```
    @all_fields_optional
    class ContainerDeviceRequest(DockerCamelModel):
        driver: str
        count: int
>       device_ids: List[str] = pydantic.Field(alias="DeviceIDs")
E       TypeError: Field() missing 1 required positional argument: 'default'

.venv/lib/python3.10/site-packages/python_on_whales/components/container/models.py:64: TypeError
```

Likely for all these cases, the default could be set to `...`, but you have a decent number of `Field` usages, and this seemed less invasive a solution reflecting the current state of the code base.