### PR TITLE
feat: Support for using docker-compose binary instead of docker compose add-in

### DIFF
--- a/python_on_whales/client_config.py
+++ b/python_on_whales/client_config.py
@@ -107,9 +107,13 @@ class ClientConfig:
         )
 
     def _get_docker_compose_path(self) -> List[str]:
-        if 0 == subprocess.call(["docker", "compose"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
+        if 0 == subprocess.call(
+            ["docker", "compose"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        ):
             return ["docker", "compose"]
-        elif 0 == subprocess.call(["docker-compose"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL):
+        elif 0 == subprocess.call(
+            ["docker-compose"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        ):
             return ["docker-compose"]
 
         raise ClientNotFoundError(
@@ -120,7 +124,9 @@ class ClientConfig:
 
     def _get_docker_compose_call_with_path(self) -> List[Union[Path, str]]:
         if self._docker_compose_call_with_path is None:
-            self._docker_compose_call_with_path = list(map(Path, self._get_docker_compose_path())) + self.client_call[1:]
+            self._docker_compose_call_with_path = (
+                list(map(Path, self._get_docker_compose_path())) + self.client_call[1:]
+            )
 
         return self._docker_compose_call_with_path
 

--- a/python_on_whales/client_config.py
+++ b/python_on_whales/client_config.py
@@ -113,9 +113,9 @@ class ClientConfig:
             return ["docker-compose"]
 
         raise ClientNotFoundError(
-            f"The binary 'docker-compose' or the docker compose add-in could not be found on your PATH. "
-            f"Please ensure that your PATH is has the directory of the binary you're looking for. "
-            f"You can use `print(os.environ['PATH'])` to verify what directories are in your PATH."
+            "The binary 'docker-compose' or the docker compose add-in could not be found on your PATH. "
+            "Please ensure that your PATH is has the directory of the binary you're looking for. "
+            "You can use `print(os.environ['PATH'])` to verify what directories are in your PATH."
         )
 
     def _get_docker_compose_call_with_path(self) -> List[Union[Path, str]]:


### PR DESCRIPTION
This PR contains changes which adds support to use the `docker-compose` binary instead of the `docker compose` add-in. 
This also allows phython-on-whales to be used with podman, since podman itself does not provide compose support.