### PR TITLE
Add `__all__` to specify what `*` should import from the main module

### DIFF
--- a/python_on_whales/__init__.py
+++ b/python_on_whales/__init__.py
@@ -22,3 +22,25 @@ from .exceptions import DockerException
 
 # alias
 docker = DockerClient()
+
+__all__ = [
+    "Builder",
+    "ClientNotFoundError",
+    "Config",
+    "Container",
+    "ContainerStats",
+    "Context",
+    "DockerContextConfig",
+    "DockerException",
+    "Image",
+    "KubernetesContextConfig",
+    "Network",
+    "Node",
+    "Plugin",
+    "Secret",
+    "Service",
+    "Stack",
+    "SystemInfo",
+    "Task",
+    "Volume",
+]


### PR DESCRIPTION
I think it is a common practice, but I'm not an expert. Feel free to accept/deny or suggest changes.