### PR TITLE
`return_stderr` should be True for `run` method to return tuple

### DIFF
--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -75,12 +75,12 @@ class DockerCamelModel(pydantic.BaseModel):
 @overload
 def run(
     args: List[Any],
-    capture_stdout: bool = True,
-    capture_stderr: bool = True,
-    input: bytes = None,
-    return_stderr: Literal[True] = True,
-    env: Dict[str, str] = {},
-    tty: bool = False,
+    capture_stdout: bool = ...,
+    capture_stderr: bool = ...,
+    input: bytes = ...,
+    return_stderr: Literal[True] = ...,
+    env: Dict[str, str] = ...,
+    tty: bool = ...,
 ) -> Tuple[str, str]:
     ...
 
@@ -88,12 +88,12 @@ def run(
 @overload
 def run(
     args: List[Any],
-    capture_stdout: bool = True,
-    capture_stderr: bool = True,
-    input: bytes = None,
-    return_stderr: Literal[False] = False,
-    env: Dict[str, str] = {},
-    tty: bool = False,
+    capture_stdout: bool = ...,
+    capture_stderr: bool = ...,
+    input: bytes = ...,
+    return_stderr: Literal[False] = ...,
+    env: Dict[str, str] = ...,
+    tty: bool = ...,
 ) -> str:
     ...
 

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -78,7 +78,7 @@ def run(
     capture_stdout: bool = True,
     capture_stderr: bool = True,
     input: bytes = None,
-    return_stderr: Literal[True] = False,
+    return_stderr: Literal[True] = True,
     env: Dict[str, str] = {},
     tty: bool = False,
 ) -> Tuple[str, str]:


### PR DESCRIPTION
I think it's intended to work that way 