### PR TITLE
Add support for the --cgroupns arg

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -492,6 +492,7 @@ class ContainerCLI(DockerCLICaller):
         cap_add: List[str] = [],
         cap_drop: List[str] = [],
         cgroup_parent: Optional[str] = None,
+        cgroupns: Optional[str] = None,
         cidfile: Optional[ValidPath] = None,
         cpu_period: Optional[int] = None,
         cpu_quota: Optional[int] = None,
@@ -617,6 +618,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_args_list("--cap-drop", cap_drop)
 
         full_cmd.add_simple_arg("--cgroup-parent", cgroup_parent)
+        full_cmd.add_simple_arg("--cgroupns", cgroupns)
         full_cmd.add_simple_arg("--cidfile", cidfile)
 
         full_cmd.add_simple_arg("--cpu-period", cpu_period)
@@ -1180,6 +1182,7 @@ class ContainerCLI(DockerCLICaller):
         cap_add: List[str] = [],
         cap_drop: List[str] = [],
         cgroup_parent: Optional[str] = None,
+        cgroupns: Optional[str] = None,
         cidfile: Optional[ValidPath] = None,
         cpu_period: Optional[int] = None,
         cpu_quota: Optional[int] = None,
@@ -1449,6 +1452,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_args_list("--cap-drop", cap_drop)
 
         full_cmd.add_simple_arg("--cgroup-parent", cgroup_parent)
+        full_cmd.add_simple_arg("--cgroupns", cgroupns)
         full_cmd.add_simple_arg("--cidfile", cidfile)
 
         full_cmd.add_simple_arg("--cpu-period", cpu_period)

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1349,6 +1349,7 @@ class ContainerCLI(DockerCLICaller):
                 `add_hosts=[("my_host_1", "192.168.30.31"), ("host2", "192.168.80.81")]`
             blkio_weight: Block IO (relative weight), between 10 and 1000,
                 or 0 to disable (default 0)
+            cgroupns: Cgroup namespace mode to use, one of 'host' or 'private'.
             cpu_period: Limit CPU CFS (Completely Fair Scheduler) period
             cpu_quota: Limit CPU CFS (Completely Fair Scheduler) quota
             cpu_rt_period: Limit CPU real-time period in microseconds

--- a/python_on_whales/components/container/models.py
+++ b/python_on_whales/components/container/models.py
@@ -172,7 +172,7 @@ class ContainerHostConfig(DockerCamelModel):
     capabilities: List[str]
     cap_add: List[str]
     cap_drop: List[str]
-    cgroupns_mode: Optional[str]
+    cgroupns_mode: str
     dns: List[str]
     dns_options: List[str]
     dns_search: List[str]

--- a/python_on_whales/components/container/models.py
+++ b/python_on_whales/components/container/models.py
@@ -172,6 +172,7 @@ class ContainerHostConfig(DockerCamelModel):
     capabilities: List[str]
     cap_add: List[str]
     cap_drop: List[str]
+    cgroupns_mode: Optional[str]
     dns: List[str]
     dns_options: List[str]
     dns_search: List[str]

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -142,6 +142,13 @@ def test_container_create_with_random_ports():
         assert container.network_settings.ports["90/tcp"][0]["HostPort"] is not None
 
 
+def test_container_create_with_cgroupns():
+    with docker.container.run(
+        "ubuntu", ["sleep", "infinity"], cgroupns="host"
+    ) as container:
+        assert container.host_config.cgroupns_mode == "host"
+
+
 def test_fails_correctly_create_start():
     python_code = """
 import sys

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -144,7 +144,7 @@ def test_container_create_with_random_ports():
 
 def test_container_create_with_cgroupns():
     with docker.container.run(
-        "ubuntu", ["sleep", "infinity"], cgroupns="host"
+        "ubuntu", ["sleep", "infinity"], cgroupns="host", detach=True, stop_timeout=1
     ) as container:
         assert container.host_config.cgroupns_mode == "host"
 


### PR DESCRIPTION
See https://docs.docker.com/engine/reference/commandline/create/#options.

This arg was added in https://github.com/docker/cli/pull/2024, v20.10.0 ([link](https://docs.docker.com/engine/release-notes/#client-7)), and is also [supported by podman](https://docs.podman.io/en/latest/markdown/podman-run.1.html#cgroupns-mode).

I've tested this works manually, unsure if you think automated testing should somehow be added too?