### PR TITLE
Fix legacy build with podman when there is output on stderr

### DIFF
--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -279,7 +279,7 @@ class ImageCLI(DockerCLICaller):
             self.client_config
         )
         full_cmd.append(context_path)
-        image_id = run(full_cmd, return_stderr=True)[0].strip()
+        image_id = run(full_cmd).splitlines()[-1].strip()
         return docker_image.inspect(image_id)
 
     def history(self):

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -279,7 +279,7 @@ class ImageCLI(DockerCLICaller):
             self.client_config
         )
         full_cmd.append(context_path)
-        image_id = run(full_cmd).strip()
+        image_id = run(full_cmd, return_stderr=True)[0].strip()
         return docker_image.inspect(image_id)
 
     def history(self):


### PR DESCRIPTION
Fixes https://github.com/gabrieldemarmiesse/python-on-whales/issues/401

When using 'ctr-mgr build --quiet':
- Docker only outputs image ID (good)
- Podman v3.4.2 outputs stderr from 'RUN' commands to stderr (hmm)
- Podman-remote outputs the stderr from podman to stdout (bad)

Solution for all these cases is to take the last line of the output.

Tested manually with podman-remote.

```
root@ubuntu:~/ctrbuild# cat Dockerfile
FROM alpine
RUN sh -c 'echo "hello" >&2'
root@ubuntu:~/ctrbuild# podman build . -q --no-cache
hello
93eb2c508f2ce21bd39bc86cfea804119a5302994cc8bd94168c46aa9d00ca3b
root@ubuntu:~/ctrbuild# docker build . -q --no-cache
sha256:4c79a365502b79abb668f06ae4ddde5bdfd893d7673c9b10f1987aee970130a0
```