### PR TITLE
Add Imagetools create command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,10 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
     hooks:
       - id: isort
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -2,11 +2,9 @@ import json
 from typing import Any, Dict, Iterator, Optional, Union
 
 from python_on_whales.client_config import DockerCLICaller
-from python_on_whales.components.buildx.cli_wrapper import stream_buildx_logs
 from python_on_whales.utils import run
 
 from .models import Manifest
-
 
 class ImagetoolsCLI(DockerCLICaller):
     def inspect(self, name: str) -> Manifest:
@@ -18,7 +16,7 @@ class ImagetoolsCLI(DockerCLICaller):
     def create(
         self,
         source: str,
-        tag: str,
+        tag: Optional[str],
         append: bool = False,
         stream_logs: bool = False,
         file: Optional[str] = None,
@@ -61,3 +59,8 @@ class ImagetoolsCLI(DockerCLICaller):
         else:
             run(full_cmd)
             return json.loads(run(full_cmd + source))
+
+
+def stream_buildx_logs(full_cmd: list, env: Dict[str, str] = None) -> Iterator[str]:
+    for origin, value in stream_stdout_and_stderr(full_cmd, env=env):
+        yield value.decode(errors="replace")

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterator, Optional, Union
 import json
 
 from python_on_whales.client_config import DockerCLICaller

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -2,9 +2,10 @@ import json
 from typing import Any, Dict, Iterator, Optional, Union
 
 from python_on_whales.client_config import DockerCLICaller
-from python_on_whales.utils import run
+from python_on_whales.utils import run, stream_stdout_and_stderr
 
 from .models import Manifest
+
 
 class ImagetoolsCLI(DockerCLICaller):
     def inspect(self, name: str) -> Manifest:

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -24,7 +24,7 @@ class ImagetoolsCLI(DockerCLICaller):
         file: Optional[str] = None,
         progress: Union[str, bool] = "auto",
         dry_run: Optional[bool] = False,
-        builder: Optional[str] = None, # TODO: inherit ValidBuilder from python_on_whales.components.buildx.cli_wrapper?
+        builder: Optional[str] = None,
         ) -> Union[Dict[str, Dict[str, Dict[str, Any]]], Iterator[str]]:
         """
         Create a new manifest list based on source manifests.

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from python_on_whales.client_config import DockerCLICaller
 from python_on_whales.utils import run
@@ -16,10 +16,10 @@ class ImagetoolsCLI(DockerCLICaller):
 
     def create(
         self,
-        sources: list[str] = [],
-        tags: list[str] = [],
+        sources: List[str] = [],
+        tags: List[str] = [],
         append: bool = False,
-        files: list[Union[str, Path]] = [],
+        files: List[Union[str, Path]] = [],
         dry_run: bool = False,
         builder: Optional[str] = None,
     ) -> Optional[Manifest]:

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -38,7 +38,7 @@ class ImagetoolsCLI(DockerCLICaller):
         # Arguments
             source: The source manifest to create, change
             append: Append to existing manifest
-            dru_run: Show final image instead of pushing
+            dry_run: Show final image instead of pushing
             file: Read source descriptor from file
             progress: Set type of progress output (`"auto"`, `"plain"`, `"tty"`,
                 or `False`). Use plain to keep the container output on screen

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -33,7 +33,7 @@ class ImagetoolsCLI(DockerCLICaller):
         and it contains a lot more information.
 
         # Arguments
-            source: The source manifest to create, change
+            sources: The sources manifest to create, change
             append: Append to existing manifest
             dry_run: Show final image instead of pushing
             files: Read source descriptor from file

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -1,5 +1,5 @@
-from typing import Any, Dict, Iterator, Optional, Union
 import json
+from typing import Any, Dict, Iterator, Optional, Union
 
 from python_on_whales.client_config import DockerCLICaller
 from python_on_whales.components.buildx.cli_wrapper import stream_buildx_logs

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -25,7 +25,7 @@ class ImagetoolsCLI(DockerCLICaller):
         progress: Union[str, bool] = "auto",
         dry_run: Optional[bool] = False,
         builder: Optional[str] = None,
-        ) -> Union[Dict[str, Dict[str, Dict[str, Any]]], Iterator[str]]:
+    ) -> Union[Dict[str, Dict[str, Dict[str, Any]]], Iterator[str]]:
         """
         Create a new manifest list based on source manifests.
         The source manifests can be manifest lists or single platform distribution manifests and

--- a/python_on_whales/components/buildx/imagetools/cli_wrapper.py
+++ b/python_on_whales/components/buildx/imagetools/cli_wrapper.py
@@ -1,4 +1,8 @@
+from typing import Any, Dict, Iterator, List, Optional, Union
+import json
+
 from python_on_whales.client_config import DockerCLICaller
+from python_on_whales.components.buildx.cli_wrapper import stream_buildx_logs
 from python_on_whales.utils import run
 
 from .models import Manifest
@@ -10,3 +14,50 @@ class ImagetoolsCLI(DockerCLICaller):
         full_cmd = self.docker_cmd + ["buildx", "imagetools", "inspect", "--raw", name]
         result = run(full_cmd)
         return Manifest.parse_raw(result)
+
+    def create(
+        self,
+        source: str,
+        tag: str,
+        append: bool = False,
+        stream_logs: bool = False,
+        file: Optional[str] = None,
+        progress: Union[str, bool] = "auto",
+        dry_run: Optional[bool] = False,
+        builder: Optional[str] = None, # TODO: inherit ValidBuilder from python_on_whales.components.buildx.cli_wrapper?
+        ) -> Union[Dict[str, Dict[str, Dict[str, Any]]], Iterator[str]]:
+        """
+        Create a new manifest list based on source manifests.
+        The source manifests can be manifest lists or single platform distribution manifests and
+        must already exist in the registry where the new manifest is created.
+        If only one source is specified, create performs a carbon copy.
+
+        The CLI docs is [here](https://docs.docker.com/engine/reference/commandline/buildx_imagetools_create/)
+        and it contains a lot more information.
+
+        # Arguments
+            source: The source manifest to create, change
+            append: Append to existing manifest
+            dru_run: Show final image instead of pushing
+            file: Read source descriptor from file
+            progress: Set type of progress output (`"auto"`, `"plain"`, `"tty"`,
+                or `False`). Use plain to keep the container output on screen
+            builder: The builder to use.
+
+        """
+        full_cmd = self.docker_cmd + ["buildx", "imagetools", "create"]
+
+        if progress != "auto" and isinstance(progress, str):
+            full_cmd += ["--progress", progress]
+
+        full_cmd.add_simple_arg("--tag", tag)
+        full_cmd.add_simple_arg("--file", file)
+        full_cmd.add_simple_arg("--builder", builder)
+        full_cmd.add_flag("--append", append)
+        full_cmd.add_flag("--dry_run", dry_run)
+
+        if stream_logs:
+            return stream_buildx_logs(full_cmd + source)
+        else:
+            run(full_cmd)
+            return json.loads(run(full_cmd + source))

--- a/tests/python_on_whales/components/buildx/imagetools/test_imagetools_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/imagetools/test_imagetools_cli_wrapper.py
@@ -19,6 +19,7 @@ def test_imagetools_inspect_single_image():
     assert a.schema_version == 2
     assert a.config.media_type.startswith("application/")
 
+
 def test_imagetools_create_multiarch():
     a = docker.buildx.imagetools.create("python:3.7.0")
     assert a.media_type.startswith("application/")
@@ -54,6 +55,7 @@ def test_use_builder():
         docker.buildx.use(my_builder)
         docker.buildx.use("default")
         docker.buildx.use(my_builder, default=True, global_=True)
+
 
 @pytest.mark.usefixtures("with_docker_driver")
 @pytest.mark.usefixtures("change_cwd")

--- a/tests/python_on_whales/components/buildx/imagetools/test_imagetools_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/imagetools/test_imagetools_cli_wrapper.py
@@ -1,5 +1,3 @@
-import pytest
-
 from python_on_whales import docker
 from python_on_whales.utils import PROJECT_ROOT
 
@@ -20,50 +18,53 @@ def test_imagetools_inspect_single_image():
     assert a.config.media_type.startswith("application/")
 
 
-def test_imagetools_create_multiarch():
-    a = docker.buildx.imagetools.create("python:3.7.0")
+def test_imagetools_create_single_image():
+    a = docker.buildx.imagetools.create(["python:3.7.0"], dry_run=True)
     assert a.media_type.startswith("application/")
 
 
-def test_imagetools_create_single_image():
-    a = docker.buildx.imagetools.inspect(
-        "python@sha256:b48b88687b1376f3135a048c8cdaccad4e8dd1af2f345c693a39b75a5683a3eb"
+def test_imagetools_create_single_image_with_hash():
+    a = docker.buildx.imagetools.create(
+        [
+            "python@sha256:b48b88687b1376f3135a048c8cdaccad4e8dd1af2f345c693a39b75a5683a3eb"
+        ],
+        dry_run=True,
     )
     assert a.schema_version == 2
-    assert a.config.media_type.startswith("application/")
+    assert a.media_type.startswith("application/")
 
 
-def test_builder_name():
-    my_builder = docker.buildx.create(name="some_builder")
-    with my_builder:
-        assert my_builder.name == "some_builder"
+def test_imagetools_create_new_image_with_tag(docker_registry):
+    busybox = docker.pull("busybox:1")
+    base_image = f"{docker_registry}/test:image1"
+    docker.tag(busybox, base_image)
+    docker.push(base_image)
+    new_image = f"{docker_registry}/test:image2"
+    docker.buildx.imagetools.create([base_image], tags=[new_image])
+    docker.pull(new_image)
 
 
-def test_builder_options():
-    my_builder = docker.buildx.create(driver_options=dict(network="host"))
-    my_builder.remove()
+def test_imagetools_create_new_image_with_tags(docker_registry):
+    busybox = docker.pull("busybox:1")
+    base_image = f"{docker_registry}/test:image1"
+    docker.tag(busybox, base_image)
+    docker.push(base_image)
+    new_image_2 = f"{docker_registry}/test:image2"
+    new_image_3 = f"{docker_registry}/test:image3"
+    docker.buildx.imagetools.create([base_image], tags=[new_image_2, new_image_3])
+    docker.pull([new_image_2, new_image_3])
 
 
-def test_builder_set_driver():
-    my_builder = docker.buildx.create(driver="docker-container")
-    my_builder.remove()
-
-
-def test_use_builder():
-    my_builder = docker.buildx.create()
-    with my_builder:
-        docker.buildx.use(my_builder)
-        docker.buildx.use("default")
-        docker.buildx.use(my_builder, default=True, global_=True)
-
-
-@pytest.mark.usefixtures("with_docker_driver")
-@pytest.mark.usefixtures("change_cwd")
-def test_bake_stream_logs(monkeypatch):
-    monkeypatch.setenv("IMAGE_NAME_1", "dodo")
-    output = docker.buildx.bake(
-        files=[bake_file], variables={"TAG": "3.0.4"}, stream_logs=True
-    )
-    output = list(output)
-    assert output[0].startswith("#")
-    assert output[-1].startswith("#")
+def test_imagetools_append(docker_registry):
+    busybox = docker.pull("busybox:1")
+    alpine = docker.pull("alpine")
+    base_image_busybox = f"{docker_registry}/test:busybox"
+    base_image_alpine = f"{docker_registry}/test:alpine"
+    docker.tag(busybox, base_image_busybox)
+    docker.tag(alpine, base_image_alpine)
+    docker.push(base_image_busybox)
+    docker.push(base_image_alpine)
+    new_image = f"{docker_registry}/test:image2"
+    docker.buildx.imagetools.create([base_image_busybox], tags=[new_image])
+    docker.buildx.imagetools.create([base_image_alpine], tags=[new_image], append=True)
+    docker.pull(new_image)

--- a/tests/python_on_whales/components/buildx/imagetools/test_imagetools_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/imagetools/test_imagetools_cli_wrapper.py
@@ -1,4 +1,10 @@
+import pytest
+
 from python_on_whales import docker
+from python_on_whales.utils import PROJECT_ROOT
+
+bake_test_dir = PROJECT_ROOT / "tests/python_on_whales/components/bake_tests"
+bake_file = bake_test_dir / "docker-bake.hcl"
 
 
 def test_imagetools_inspect_multiarch():
@@ -12,3 +18,50 @@ def test_imagetools_inspect_single_image():
     )
     assert a.schema_version == 2
     assert a.config.media_type.startswith("application/")
+
+def test_imagetools_create_multiarch():
+    a = docker.buildx.imagetools.create("python:3.7.0")
+    assert a.media_type.startswith("application/")
+
+
+def test_imagetools_create_single_image():
+    a = docker.buildx.imagetools.inspect(
+        "python@sha256:b48b88687b1376f3135a048c8cdaccad4e8dd1af2f345c693a39b75a5683a3eb"
+    )
+    assert a.schema_version == 2
+    assert a.config.media_type.startswith("application/")
+
+
+def test_builder_name():
+    my_builder = docker.buildx.create(name="some_builder")
+    with my_builder:
+        assert my_builder.name == "some_builder"
+
+
+def test_builder_options():
+    my_builder = docker.buildx.create(driver_options=dict(network="host"))
+    my_builder.remove()
+
+
+def test_builder_set_driver():
+    my_builder = docker.buildx.create(driver="docker-container")
+    my_builder.remove()
+
+
+def test_use_builder():
+    my_builder = docker.buildx.create()
+    with my_builder:
+        docker.buildx.use(my_builder)
+        docker.buildx.use("default")
+        docker.buildx.use(my_builder, default=True, global_=True)
+
+@pytest.mark.usefixtures("with_docker_driver")
+@pytest.mark.usefixtures("change_cwd")
+def test_bake_stream_logs(monkeypatch):
+    monkeypatch.setenv("IMAGE_NAME_1", "dodo")
+    output = docker.buildx.bake(
+        files=[bake_file], variables={"TAG": "3.0.4"}, stream_logs=True
+    )
+    output = list(output)
+    assert output[0].startswith("#")
+    assert output[-1].startswith("#")


### PR DESCRIPTION
### Background
- What problem were you trying to solve
  - Would like to the ability to run `docker buildx imagetools create ...`
- Related links:
  - https://docs.docker.com/engine/reference/commandline/buildx_imagetools_create/

### Changes
- Add `create` method to `ImagetoolsCLI`
- pre-commit changes
  - `https://gitlab.com/pycqa/flake8`
    - change to `github` url as it's more popular (gitlab requires login)
  - Upgraded `isort`: https://github.com/PyCQA/isort/issues/2077
  - Use new repository names
    - `isort`
    - `ambv`

### Open questions / follow-up work
- Create unittest?
