### PR TITLE
:sparkles: Better error message when using command as a string

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1432,6 +1432,16 @@ class ContainerCLI(DockerCLICaller):
             The container output as a string if detach is `False` (the default),
             and a `python_on_whales.Container` if detach is `True`.
         """
+        if not isinstance(command, list):
+            error_message = ("When calling docker.run(), the second argument ('command') "
+            "should be a list, not a string."
+            "Here are some examples:"
+            "docker.run('ubuntu', ['ls']), "
+            "docker.run('ubuntu', ['cat', '/some/file.txt'])")
+            if isinstance(command, str):
+                # boy this is the most common error in the world
+                error_message += f" In your case, you can try docker.run('{image}', {command.split()}, ...)."
+            raise TypeError(error_message)
 
         image_cli = python_on_whales.components.image.cli_wrapper.ImageCLI(
             self.client_config

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1452,7 +1452,7 @@ class ContainerCLI(DockerCLICaller):
         if not isinstance(command, list):
             error_message = (
                 "When calling docker.run(), the second argument ('command') "
-                "should be a list."
+                "should be a list. "
                 "Here are some examples:"
                 "docker.run('ubuntu', ['ls']), "
                 "docker.run('ubuntu', ['cat', '/some/file.txt'])"

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -833,7 +833,7 @@ class ContainerCLI(DockerCLICaller):
         if not isinstance(command, list):
             error_message = (
                 "When calling docker.execute(), the second argument ('command') "
-                "should be a list."
+                "should be a list. "
                 "Here are some examples:"
                 "docker.execute('somecontainer', ['ls']), "
                 "docker.execute('somecontainer', ['cat', '/some/file.txt'])"

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -830,6 +830,23 @@ class ContainerCLI(DockerCLICaller):
         # Raises
             `python_on_whales.exceptions.NoSuchContainer` if the container does not exists.
         """
+        if not isinstance(command, list):
+            error_message = (
+                "When calling docker.execute(), the second argument ('command') "
+                "should be a list."
+                "Here are some examples:"
+                "docker.execute('somecontainer', ['ls']), "
+                "docker.execute('somecontainer', ['cat', '/some/file.txt'])"
+            )
+            if isinstance(command, str):
+                # boy this is the most common error in the world
+                if isinstance(container, str):
+                    container = self.inspect(container)
+                error_message += (
+                    f" In your case, command should not be a string. "
+                    f"You can try docker.execute('{container.name}', {command.split()}, ...)."
+                )
+            raise TypeError(error_message)
         full_cmd = self.docker_cmd + ["exec"]
 
         full_cmd.add_flag("--detach", detach)
@@ -1433,14 +1450,19 @@ class ContainerCLI(DockerCLICaller):
             and a `python_on_whales.Container` if detach is `True`.
         """
         if not isinstance(command, list):
-            error_message = ("When calling docker.run(), the second argument ('command') "
-            "should be a list, not a string."
-            "Here are some examples:"
-            "docker.run('ubuntu', ['ls']), "
-            "docker.run('ubuntu', ['cat', '/some/file.txt'])")
+            error_message = (
+                "When calling docker.run(), the second argument ('command') "
+                "should be a list."
+                "Here are some examples:"
+                "docker.run('ubuntu', ['ls']), "
+                "docker.run('ubuntu', ['cat', '/some/file.txt'])"
+            )
             if isinstance(command, str):
                 # boy this is the most common error in the world
-                error_message += f" In your case, you can try docker.run('{image}', {command.split()}, ...)."
+                error_message += (
+                    f" In your case, command should not be a string. "
+                    f"You can try docker.run('{image}', {command.split()}, ...)."
+                )
             raise TypeError(error_message)
 
         image_cli = python_on_whales.components.image.cli_wrapper.ImageCLI(

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -31,6 +31,13 @@ def test_simple_command():
     assert "Hello from Docker!" in output
 
 
+def test_simple_mistake_on_run():
+    with pytest.raises(TypeError) as err:
+        docker.run("ubuntu", "ls")
+    assert "docker.run('ubuntu', ['ls'], ...)" in str(err)
+    docker.run("ubuntu", ["ls"], remove=True)
+
+
 def test_simple_command_create_start():
     output = docker.container.create("hello-world", remove=True).start(attach=True)
     assert "Hello from Docker!" in output
@@ -322,6 +329,17 @@ def test_execute():
     exec_result = docker.execute(my_container, ["echo", "dodo"])
     assert exec_result == "dodo"
     docker.kill(my_container)
+
+
+def test_execute_simple_mistake():
+    with docker.run(
+        "busybox:1", ["sleep", "infinity"], detach=True, remove=True
+    ) as my_container:
+        with pytest.raises(TypeError) as err:
+            docker.execute(my_container, "echo dodo")
+        assert f"docker.execute('{my_container.name}', ['echo', 'dodo'], ...)" in str(
+            err
+        )
 
 
 def test_execute_stream():


### PR DESCRIPTION
```
In [1]: from python_on_whales import docker

In [2]: docker.run("ubuntu", "ls")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 docker.run("ubuntu", "ls")

File /projects/open_source/python-on-whales/python_on_whales/components/container/cli_wrapper.py:1444, in ContainerCLI.run(self, image, command, add_hosts, blkio_weight, blkio_weight_device, cap_add, cap_drop, cgroup_parent, cgroupns, cidfile, cpu_period, cpu_quota, cpu_rt_period, cpu_rt_runtime, cpu_shares, cpus, cpuset_cpus, cpuset_mems, detach, devices, device_cgroup_rules, device_read_bps, device_read_iops, device_write_bps, device_write_iops, content_trust, dns, dns_options, dns_search, domainname, entrypoint, envs, env_files, expose, gpus, groups_add, healthcheck, health_cmd, health_interval, health_retries, health_start_period, health_timeout, hostname, init, interactive, ip, ip6, ipc, isolation, kernel_memory, labels, label_files, link, link_local_ip, log_driver, log_options, mac_address, memory, memory_reservation, memory_swap, memory_swappiness, mounts, name, networks, network_aliases, oom_kill, oom_score_adj, pid, pids_limit, platform, privileged, publish, publish_all, pull, read_only, restart, remove, runtime, security_options, shm_size, sig_proxy, stop_signal, stop_timeout, storage_options, stream, sysctl, tmpfs, tty, ulimit, user, userns, uts, volumes, volume_driver, volumes_from, workdir)
   1441     if isinstance(command, str):
   1442         # boy this is the most common error in the world
   1443         error_message += f" In your case, you can try docker.run('{image}', {command.split()}, ...)."
-> 1444     raise TypeError(error_message)
   1446 image_cli = python_on_whales.components.image.cli_wrapper.ImageCLI(
   1447     self.client_config
   1448 )
   1449 if pull == "missing":

TypeError: When calling docker.run(), the second argument ('command') should be a list, not a string.Here are some examples:docker.run('ubuntu', ['ls']), docker.run('ubuntu', ['cat', '/some/file.txt']) In your case, you can try docker.run('ubuntu', ['ls'], ...).

In [3]: docker.run("ubuntu", ["ls"])
Out[3]: 'bin\nboot\ndev\netc\nhome\nlib\nlib32\nlib64\nlibx32\nmedia\nmnt\nopt\nproc\nroot\nrun\nsbin\nsrv\nsys\ntmp\nusr\nvar'

```