### PR TITLE
:sparkles: Add more precise type hints for filters in docker.ps()

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -4,7 +4,18 @@ import inspect
 import json
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, overload
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypedDict,
+    Union,
+    overload,
+)
 
 import pydantic
 
@@ -34,6 +45,30 @@ from python_on_whales.utils import (
     run,
     stream_stdout_and_stderr,
     to_list,
+)
+
+DockerContainerListFilters = TypedDict(
+    "DockerContainerListFilters",
+    {
+        "id": str,
+        "name": str,
+        "label": str,
+        "exited": int,
+        "status": Literal[
+            "created", "restarting", "running", "removing", "paused", "exited", "dead"
+        ],
+        "ancestor": str,
+        "before": str,  # TODO: allow datetime
+        "since": str,  # TODO: allow datetime
+        "volume": str,  # TODO: allow Volumes
+        "network": str,  # TODO: allow Network
+        "publish": str,
+        "expose": str,
+        "health": Literal["starting", "healthy", "unhealthy", "none"],
+        "isolation": Literal["default", "process", "hyperv"],
+        "is-task": str,  # TODO: allow bool
+    },
+    total=False,
 )
 
 
@@ -1049,7 +1084,9 @@ class ContainerCLI(DockerCLICaller):
         else:
             return "".join(x[1].decode() for x in iterator)
 
-    def list(self, all: bool = False, filters: Dict[str, str] = {}) -> List[Container]:
+    def list(
+        self, all: bool = False, filters: DockerContainerListFilters = {}
+    ) -> List[Container]:
         """List the containers on the host.
 
         Alias: `docker.ps(...)`


### PR DESCRIPTION
Exciting stuff, even if pycharm doesn't detect the error right away, mypy does a very good job with this:

```python
from python_on_whales import docker

docker.ps(filters={"stats": "somthing"})

# from mypy: error: Extra key "stats" for TypedDict "DockerContainerListFilters"  [typeddict-unknown-key]
```


```python
from python_on_whales import docker

docker.ps(filters={"status": "somthing"})

# from mypy: error: Incompatible types (expression has type "Literal['somthing']", TypedDict item "status" has type "Literal['created', 'restarting', 'running', 'removing', 'paused', 'exited', 'dead']")  [typeddict-item]
```


```python
from python_on_whales import docker

docker.ps(filters={"status": "exited"})

# from mypy: Success: no issues found in 1 source file
```