### PR TITLE
Support passing signals as integers (or signal.Signals enum instances)

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -12,6 +12,7 @@ from python_on_whales.client_config import DockerCLICaller
 from python_on_whales.components.compose.models import ComposeConfig, ComposeProject
 from python_on_whales.utils import (
     format_dict_for_cli,
+    format_signal_arg,
     parse_ls_status_count,
     run,
     stream_stdout_and_stderr,
@@ -205,7 +206,9 @@ class ComposeCLI(DockerCLICaller):
             return run(full_cmd)
 
     def kill(
-        self, services: Union[str, List[str]] = None, signal: Optional[str] = None
+        self,
+        services: Union[str, List[str]] = None,
+        signal: Optional[Union[int, str]] = None,
     ):
         """Kills the container(s) of a service
 
@@ -218,7 +221,7 @@ class ComposeCLI(DockerCLICaller):
             signal: the signal to send to the container. Default is `"SIGKILL"`
         """
         full_cmd = self.docker_compose_cmd + ["kill"]
-        full_cmd.add_simple_arg("--signal", signal)
+        full_cmd.add_simple_arg("--signal", format_signal_arg(signal))
         if services == []:
             return
         elif services is not None:

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -40,6 +40,7 @@ from python_on_whales.exceptions import NoSuchContainer
 from python_on_whales.utils import (
     ValidPath,
     format_dict_for_cli,
+    format_signal_arg,
     format_time_arg,
     removeprefix,
     run,
@@ -297,7 +298,7 @@ class Container(ReloadableObjectFromJson):
         """
         return ContainerCLI(self.client_config).export(self, output)
 
-    def kill(self, signal: str = None):
+    def kill(self, signal: Optional[Union[int, str]] = None):
         """Kill this container
 
         See the [`docker.container.kill`](../sub-commands/container.md#kill) command for
@@ -601,7 +602,7 @@ class ContainerCLI(DockerCLICaller):
         security_options: List[str] = [],
         shm_size: Union[int, str, None] = None,
         sig_proxy: bool = True,
-        stop_signal: Optional[str] = None,
+        stop_signal: Optional[Union[int, str]] = None,
         stop_timeout: Optional[int] = None,
         storage_options: List[str] = [],
         sysctl: Dict[str, str] = {},
@@ -762,7 +763,7 @@ class ContainerCLI(DockerCLICaller):
         if sig_proxy is False:
             full_cmd += ["--sig-proxy", "false"]
 
-        full_cmd.add_simple_arg("--stop-signal", stop_signal)
+        full_cmd.add_simple_arg("--stop-signal", format_signal_arg(stop_signal))
         full_cmd.add_simple_arg("--stop-timeout", stop_timeout)
 
         full_cmd.add_args_list("--storage-opt", storage_options)
@@ -987,7 +988,7 @@ class ContainerCLI(DockerCLICaller):
     def kill(
         self,
         containers: Union[ValidContainer, List[ValidContainer]],
-        signal: Optional[str] = None,
+        signal: Optional[Union[int, str]] = None,
     ) -> None:
         """Kill a container.
 
@@ -1007,7 +1008,7 @@ class ContainerCLI(DockerCLICaller):
             return
         full_cmd = self.docker_cmd + ["container", "kill"]
 
-        full_cmd.add_simple_arg("--signal", signal)
+        full_cmd.add_simple_arg("--signal", format_signal_arg(signal))
         full_cmd += containers
 
         run(full_cmd)
@@ -1311,7 +1312,7 @@ class ContainerCLI(DockerCLICaller):
         security_options: List[str] = [],
         shm_size: Union[int, str, None] = None,
         sig_proxy: bool = True,
-        stop_signal: Optional[str] = None,
+        stop_signal: Optional[Union[int, str]] = None,
         stop_timeout: Optional[int] = None,
         storage_options: List[str] = [],
         stream: bool = False,
@@ -1634,7 +1635,7 @@ class ContainerCLI(DockerCLICaller):
         if sig_proxy is False:
             full_cmd += ["--sig-proxy", "false"]
 
-        full_cmd.add_simple_arg("--stop-signal", stop_signal)
+        full_cmd.add_simple_arg("--stop-signal", format_signal_arg(stop_signal))
         full_cmd.add_simple_arg("--stop-timeout", stop_timeout)
 
         full_cmd.add_args_list("--storage-opt", storage_options)

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import subprocess
 import sys
 from datetime import datetime, timedelta
@@ -313,6 +314,25 @@ def format_time_for_docker(time_object: Union[datetime, timedelta]) -> str:
         return time_object.strftime("%Y-%m-%dT%H:%M:%S")
     elif isinstance(time_object, timedelta):
         return f"{time_object.total_seconds()}s"
+
+
+def format_signal_arg(signal_object: Optional[Union[int, str]]) -> Optional[str]:
+    if signal_object is None:
+        return None
+    else:
+        return format_signal_for_docker(signal_object)
+
+
+def format_signal_for_docker(signal_object: Union[int, str]) -> str:
+    if isinstance(signal_object, int):
+        return signal.Signals(signal_object).name
+    elif isinstance(signal_object, str):
+        if hasattr(signal.Signals, "SIG" + signal_object):
+            return "SIG" + signal_object
+        else:
+            return signal_object
+    else:
+        raise TypeError(f"Got unexpected signal type {type(signal_object).__name__!r}")
 
 
 def parse_ls_status_count(status_output, status) -> int:

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -322,7 +322,7 @@ def test_docker_compose_kill():
     for container in docker.compose.ps():
         assert container.state.running
 
-    docker.compose.kill("busybox")
+    docker.compose.kill("busybox", signal=9)
 
     assert not docker.container.inspect("components_busybox_1").state.running
 

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -1,4 +1,5 @@
 import json
+import signal
 import sys
 import tempfile
 import time
@@ -371,6 +372,16 @@ def test_methods():
     my_container = docker.run("busybox:1", ["sleep", "infinity"], detach=True)
     my_container.kill()
     assert not my_container.state.running
+    my_container.remove()
+
+
+def test_kill_signal():
+    my_container = docker.run(
+        "busybox:1", ["sleep", "infinity"], init=True, detach=True
+    )
+    my_container.kill(signal=signal.SIGINT)
+    assert not my_container.state.running
+    assert my_container.state.exit_code == 130
     my_container.remove()
 
 


### PR DESCRIPTION
Fixes https://github.com/gabrieldemarmiesse/python-on-whales/issues/427

Relevant python docs: https://docs.python.org/3/library/signal.html

Note that this PR makes no change to the underlying container commands being run - it converts int signals into strings before passing to the CLI. However, docker does seem to support e.g. `--signal 9` as well as `--signal SIGKILL`, and this would make it easier to pass e.g. `SIGRTMIN+3` (systemd's stop signal), which is currently not supported as an int (37). The reason for converting to string is I'm not sure if all versions of docker/podman support passing as int? I'm happy to change this (i.e. get rid of the converter in `utils.py`).