### PR TITLE
Allow container selection in 'docker stats'

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1707,7 +1707,11 @@ class ContainerCLI(DockerCLICaller):
         else:
             run(full_cmd)
 
-    def stats(self, all: bool = False) -> List[ContainerStats]:
+    def stats(
+        self,
+        containers: Union[ValidContainer, List[ValidContainer]] = [],
+        all: bool = False,
+    ) -> List[ContainerStats]:
         """Get containers resource usage statistics
 
         Alias: `docker.stats(...)`
@@ -1730,10 +1734,12 @@ class ContainerCLI(DockerCLICaller):
 
         # Arguments
             all: Get the stats of all containers, not just running ones.
+            containers: One or a list of containers.
 
         # Returns
             A `List[python_on_whales.ContainerStats]`.
         """
+        containers = to_list(containers)
         full_cmd = self.docker_cmd + [
             "container",
             "stats",
@@ -1743,6 +1749,7 @@ class ContainerCLI(DockerCLICaller):
             "--no-trunc",
         ]
         full_cmd.add_flag("--all", all)
+        full_cmd += containers
         stats_output = run(full_cmd)
         return [ContainerStats(json.loads(x)) for x in stats_output.splitlines()]
 

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1739,12 +1739,6 @@ class ContainerCLI(DockerCLICaller):
         # Returns
             A `List[python_on_whales.ContainerStats]`.
         """
-        containers = to_list(containers)
-
-        if not containers:
-            # do nothing
-            return []
-
         full_cmd = self.docker_cmd + [
             "container",
             "stats",

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1709,7 +1709,7 @@ class ContainerCLI(DockerCLICaller):
 
     def stats(
         self,
-        containers: Union[ValidContainer, List[ValidContainer]] = [],
+        containers: Optional[Union[ValidContainer, List[ValidContainer]]] = None,
         all: bool = False,
     ) -> List[ContainerStats]:
         """Get containers resource usage statistics
@@ -1740,6 +1740,11 @@ class ContainerCLI(DockerCLICaller):
             A `List[python_on_whales.ContainerStats]`.
         """
         containers = to_list(containers)
+
+        if not containers:
+            # do nothing
+            return []
+
         full_cmd = self.docker_cmd + [
             "container",
             "stats",
@@ -1749,7 +1754,10 @@ class ContainerCLI(DockerCLICaller):
             "--no-trunc",
         ]
         full_cmd.add_flag("--all", all)
-        full_cmd += containers
+
+        if None not in containers:
+            full_cmd += containers
+
         stats_output = run(full_cmd)
         return [ContainerStats(json.loads(x)) for x in stats_output.splitlines()]
 

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1749,8 +1749,13 @@ class ContainerCLI(DockerCLICaller):
         ]
         full_cmd.add_flag("--all", all)
 
-        if None not in containers:
-            full_cmd += containers
+        if containers == []:
+            return []
+        elif containers is None:
+            # the user didn't provide any filters
+            pass
+        else:
+            full_cmd += to_list(containers)
 
         stats_output = run(full_cmd)
         return [ContainerStats(json.loads(x)) for x in stats_output.splitlines()]

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -557,6 +557,10 @@ def test_docker_stats_cli_container(run_mock: Mock) -> None:
     )
 
 
+def test_docker_stats_cli_empty_selection() -> None:
+    assert docker.container.stats(containers=[]) == []
+
+
 def test_remove_anonymous_volume_too():
     container = docker.run("postgres:9.6.20-alpine", detach=True)
 

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -515,6 +515,48 @@ def test_docker_stats():
         assert stat.memory_used <= 100_000_000
 
 
+def test_docker_stats_container() -> None:
+    with docker.run("busybox", ["sleep", "infinity"], detach=True) as container:
+        with docker.run("busybox", ["sleep", "infinity"], detach=True) as _:
+            stats = docker.stats(containers=[container.id])
+            assert len(stats) == 1
+            assert stats[0].container_name == container.name
+
+
+@patch("python_on_whales.components.container.cli_wrapper.run")
+def test_docker_stats_cli_default(run_mock: Mock) -> None:
+    docker.container.stats()
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_cmd
+        + [
+            "container",
+            "stats",
+            "--format",
+            "{{json .}}",
+            "--no-stream",
+            "--no-trunc",
+        ]
+    )
+
+
+@patch("python_on_whales.components.container.cli_wrapper.run")
+def test_docker_stats_cli_container(run_mock: Mock) -> None:
+    test_containers = ["dummy_container_0", "dummy_container_1"]
+    docker.container.stats(containers=test_containers)
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_cmd
+        + [
+            "container",
+            "stats",
+            "--format",
+            "{{json .}}",
+            "--no-stream",
+            "--no-trunc",
+        ]
+        + test_containers
+    )
+
+
 def test_remove_anonymous_volume_too():
     container = docker.run("postgres:9.6.20-alpine", detach=True)
 


### PR DESCRIPTION
Hi! 😃 

I am using _python_on_whales_ at work to retrieve resources consumption per container (using command `docker stats`).

Currently, _python_on_whales_ seems to _always_ retrieve information about "all" containers:

```python
>>> from python_on_whales import docker
>>> docker.stats()
[<<class 'python_on_whales.components.container.cli_wrapper.ContainerStats'> object, attributes are block_read=0, block_write=0, cpu_percentage=0.0, container=9b136659b81a, container_id=9b136659b81af7dec9ffbacc58b6e48cf8376cee89e7fabcb0924835237a3c4f, memory_percentage=0.0, memory_used=397312, memory_limit=8324720361, container_name=amazing_fermat, net_upload=5070, net_download=0>,
 <<class 'python_on_whales.components.container.cli_wrapper.ContainerStats'> object, attributes are block_read=0, block_write=0, cpu_percentage=0.0, container=94f96d8b61d8, container_id=94f96d8b61d8f4c0b60b62b158c48d124407ef13fbbce6b0ab40ec92abf84861, memory_percentage=0.0, memory_used=413696, memory_limit=8324720361, container_name=sweet_jennings, net_upload=5110, net_download=0>,
 <<class 'python_on_whales.components.container.cli_wrapper.ContainerStats'> object, attributes are block_read=0, block_write=0, cpu_percentage=0.0, container=118be246cc17, container_id=118be246cc172ed7b18d43372d1b322d3d1c77c9e44b8d24b155aec0d09f7fd9, memory_percentage=0.0, memory_used=405504, memory_limit=8324720361, container_name=nifty_buck, net_upload=5370, net_download=0>]
```

The "problem" here is that I only require information concerning a _subset_ of the listed containers.
I am currently iterating over the resulting list and filtering/sorting out data based on the container id.

As shown below, the Docker CLI _supports_ container selection:

```bash
$ docker container stats --help
Usage:  docker container stats [OPTIONS] [CONTAINER...]

$ docker container stats
CONTAINER ID   NAME             CPU %     MEM USAGE / LIMIT   MEM %     NET I/O       BLOCK I/O   PIDS
9b136659b81a   amazing_fermat   0.00%     388KiB / 7.753GiB   0.00%     4.7kB / 0B    0B / 0B     1
94f96d8b61d8   sweet_jennings   0.00%     404KiB / 7.753GiB   0.00%     4.81kB / 0B   0B / 0B     1
118be246cc17   nifty_buck       0.00%     396KiB / 7.753GiB   0.00%     5.07kB / 0B   0B / 0B     1

$ docker container stats 9b136659b81a nifty_buck
CONTAINER ID   NAME             CPU %     MEM USAGE / LIMIT   MEM %     NET I/O       BLOCK I/O   PIDS
9b136659b81a   amazing_fermat   0.00%     388KiB / 7.753GiB   0.00%     4.7kB / 0B    0B / 0B     1
118be246cc17   nifty_buck       0.00%     396KiB / 7.753GiB   0.00%     5.07kB / 0B   0B / 0B     1
```

Therefore, I decided to implement this possible as well using _python_on_whales_.

With the proposed alterations you can now do the following:

```python
>>> from python_on_whales import docker
>>> docker.stats(containers=['9b136659b81a', 'nifty_buck'])
[<<class 'python_on_whales.components.container.cli_wrapper.ContainerStats'> object, attributes are block_read=0, block_write=0, cpu_percentage=0.0, container=9b136659b81a, container_id=9b136659b81af7dec9ffbacc58b6e48cf8376cee89e7fabcb0924835237a3c4f, memory_percentage=0.0, memory_used=397312, memory_limit=8324720361, container_name=amazing_fermat, net_upload=5070, net_download=0>,
 <<class 'python_on_whales.components.container.cli_wrapper.ContainerStats'> object, attributes are block_read=0, block_write=0, cpu_percentage=0.0, container=nifty_buck, container_id=118be246cc172ed7b18d43372d1b322d3d1c77c9e44b8d24b155aec0d09f7fd9, memory_percentage=0.0, memory_used=405504, memory_limit=8324720361, container_name=nifty_buck, net_upload=5440, net_download=0>]
```

Whenever the new argument `containers` is ignored, the existing behavior is maintained.

I also implemented some unit tests.

What do you guys think of this?