### PR TITLE
Feat: Add --no-attach option for docker.compose.up

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -672,6 +672,7 @@ class ComposeCLI(DockerCLICaller):
         start: bool = True,
         quiet: bool = False,
         wait: bool = False,
+        no_attach_services: Union[List[str], str, None] = None,
         pull: Literal["always", "missing", "never", None] = None,
     ):
         """Start the containers.
@@ -707,6 +708,7 @@ class ComposeCLI(DockerCLICaller):
             quiet: By default, some progress bars and logs are sent to stderr and stdout.
                 Set `quiet=True` to avoid having any output.
             wait: Wait for services to be running|healthy. Implies detached mode.
+            no_attach_services: The services not to attach to.
             pull: Pull image before running (“always”|”missing”|”never”).
 
         # Returns
@@ -730,6 +732,11 @@ class ComposeCLI(DockerCLICaller):
         full_cmd.add_flag("--no-start", not start)
         full_cmd.add_flag("--remove-orphans", remove_orphans)
         full_cmd.add_simple_arg("--pull", pull)
+
+        if no_attach_services is not None:
+            no_attach_services = to_list(no_attach_services)
+            for service in no_attach_services:
+                full_cmd.add_simple_arg("--no-attach", service)
 
         if services == []:
             return

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -404,6 +404,8 @@ def test_docker_compose_up_no_attach_services(capfd):
             break
     else:
         raise AssertionError("my_service is not spun up as expected")
+    docker.compose.down()
+
 
 
 def test_passing_env_files(tmp_path: Path):

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -407,7 +407,6 @@ def test_docker_compose_up_no_attach_services(capfd):
     docker.compose.down()
 
 
-
 def test_passing_env_files(tmp_path: Path):
     compose_env_file = tmp_path / "dodo.env"
     compose_env_file.write_text("SOME_VARIABLE_TO_INSERT=hello\n")


### PR DESCRIPTION
It's a PR to add --no-attach for docker.compose.up. so that the user could spin up the whole docker compose yaml services with an option not to attach to specific noisy services.