### PR TITLE
Add support for podman's `--systemd` in container run/create

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -607,6 +607,7 @@ class ContainerCLI(DockerCLICaller):
         stop_timeout: Optional[int] = None,
         storage_options: List[str] = [],
         sysctl: Dict[str, str] = {},
+        systemd: Optional[Union[bool, Literal["always"]]] = None,
         tmpfs: List[ValidPath] = [],
         ulimit: List[str] = [],
         user: Optional[str] = None,
@@ -769,6 +770,7 @@ class ContainerCLI(DockerCLICaller):
 
         full_cmd.add_args_list("--storage-opt", storage_options)
         full_cmd.add_args_list("--sysctl", format_dict_for_cli(sysctl))
+        full_cmd.add_simple_arg("--systemd", systemd)
         full_cmd.add_args_list("--tmpfs", tmpfs)
         full_cmd.add_args_list("--ulimit", ulimit)
 
@@ -1318,6 +1320,7 @@ class ContainerCLI(DockerCLICaller):
         storage_options: List[str] = [],
         stream: bool = False,
         sysctl: Dict[str, str] = {},
+        systemd: Optional[Union[bool, Literal["always"]]] = None,
         tmpfs: List[ValidPath] = [],
         tty: bool = False,
         ulimit: List[str] = [],
@@ -1474,6 +1477,8 @@ class ContainerCLI(DockerCLICaller):
                 `"4g"` for example.
             stop_timeout: Signal to stop a container (default "SIGTERM")
             storage_options: Storage driver options for the container
+            systemd: Whether to run in systemd mode. Only known to apply to Podman, see
+                https://docs.podman.io/en/latest/markdown/podman-run.1.html#systemd-true-false-always
             tty: Allocate a pseudo-TTY. Allow the process to access your terminal
                 to write on it.
             user: Username or UID (format: `<name|uid>[:<group|gid>]`)
@@ -1641,6 +1646,7 @@ class ContainerCLI(DockerCLICaller):
 
         full_cmd.add_args_list("--storage-opt", storage_options)
         full_cmd.add_args_list("--sysctl", format_dict_for_cli(sysctl))
+        full_cmd.add_simple_arg("--systemd", systemd)
         full_cmd.add_args_list("--tmpfs", tmpfs)
         full_cmd.add_args_list("--ulimit", ulimit)
 

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -157,6 +157,26 @@ def test_container_create_with_cgroupns():
         assert container.host_config.cgroupns_mode == "host"
 
 
+@patch("python_on_whales.components.container.cli_wrapper.run")
+@patch("python_on_whales.components.container.cli_wrapper.Container", Mock())
+def test_container_create_with_systemd(run_mock: Mock):
+    docker.container.create(
+        "ubuntu", ["sleep", "infinity"], systemd="always", pull="never"
+    )
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_cmd
+        + [
+            # fmt: off
+            "create",
+            "--pull", "never",
+            "--systemd", "always",
+            "ubuntu",
+            "sleep", "infinity",
+            # fmt: on
+        ]
+    )
+
+
 def test_fails_correctly_create_start():
     python_code = """
 import sys

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -5,6 +5,7 @@ import tempfile
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Literal, Union
 from unittest.mock import Mock, patch
 
 import pytest
@@ -157,11 +158,14 @@ def test_container_create_with_cgroupns():
         assert container.host_config.cgroupns_mode == "host"
 
 
+@pytest.mark.parametrize("systemd_mode", [True, False, "always"])
 @patch("python_on_whales.components.container.cli_wrapper.run")
 @patch("python_on_whales.components.container.cli_wrapper.Container", Mock())
-def test_container_create_with_systemd(run_mock: Mock):
+def test_container_create_with_systemd_mode(
+    run_mock: Mock, systemd_mode: Union[bool, Literal["always"]]
+):
     docker.container.create(
-        "ubuntu", ["sleep", "infinity"], systemd="always", pull="never"
+        "ubuntu", ["sleep", "infinity"], systemd=systemd_mode, pull="never"
     )
     run_mock.assert_called_once_with(
         docker.client_config.docker_cmd
@@ -169,7 +173,7 @@ def test_container_create_with_systemd(run_mock: Mock):
             # fmt: off
             "create",
             "--pull", "never",
-            "--systemd", "always",
+            "--systemd", systemd_mode,
             "ubuntu",
             "sleep", "infinity",
             # fmt: on


### PR DESCRIPTION
Fixes #408 

- [x] Add testcase(s)