### PR TITLE
456 use stdin to log in

### DIFF
--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -209,14 +209,18 @@ class DockerClient(DockerCLICaller):
             username: The username
             password: The password
         """
-        full_cmd = self.docker_cmd + ["login"]
+        full_cmd = self.docker_cmd + ["login", "--password-stdin"]
 
         full_cmd.add_simple_arg("--username", username)
-        full_cmd.add_simple_arg("--password", password)
         if server is not None:
             full_cmd.append(server)
 
-        run(full_cmd, capture_stderr=False, capture_stdout=False)
+        run(
+            full_cmd,
+            capture_stderr=False,
+            capture_stdout=False,
+            input=str.encode(password),
+        )
 
     def logout(self, server: Optional[str] = None):
         """Logout from a Docker registry

--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -219,7 +219,7 @@ class DockerClient(DockerCLICaller):
             full_cmd,
             capture_stderr=False,
             capture_stdout=False,
-            input=str.encode(password),
+            input=password.encode(),
         )
 
     def logout(self, server: Optional[str] = None):

--- a/tests/python_on_whales/test_exceptions.py
+++ b/tests/python_on_whales/test_exceptions.py
@@ -21,3 +21,15 @@ def test_exception_attributes():
     assert exception.return_code > 0
     assert not exception.stdout
     assert "wrong::" in exception.stderr
+
+
+def test_not_showing_password_in_exception():
+    chosen_password = "ignore_password"
+    with pytest.raises(DockerException) as excinfo:
+        docker.login(username="ignore_user", password=chosen_password)
+    exception = excinfo.value
+    assert "The docker command executed was" in str(exception)
+    assert chosen_password not in str(exception)
+    assert chosen_password not in exception.docker_command
+    assert exception.return_code > 0
+    assert not exception.stdout


### PR DESCRIPTION
Make use of stdin to login . This prevents the possibility to show the password in the process listing and in the execption thrown on error