### PR TITLE
Expose `DockerClient` from the root of the package

### DIFF
--- a/python_on_whales/__init__.py
+++ b/python_on_whales/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "Container",
     "ContainerStats",
     "Context",
+    "DockerClient",
     "DockerContextConfig",
     "DockerException",
     "Image",


### PR DESCRIPTION
Otherwise mypy compains and we have to do `from python_on_whales.docker_client import DockerClient`, which it feels like shouldn't be necessary?