### PR TITLE
use correct setting for pydantic v2

### DIFF
--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -81,9 +81,9 @@ class DockerCamelModel(pydantic.BaseModel):
         alias_generator = to_docker_camel
 
         if PYDANTIC_V2:
-            allow_population_by_field_name = True
-        else:
             populate_by_name = True
+        else:
+            allow_population_by_field_name = True
 
 
 @overload


### PR DESCRIPTION
Just uses the correct setting and removes the warning right now present in 0.64.0.

Also saw there is an issue for this: https://github.com/gabrieldemarmiesse/python-on-whales/issues/461