### PR TITLE
Remove deprecation warning when using pydantic V2

### DIFF
--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -77,12 +77,11 @@ def to_docker_camel(string):
 
 
 class DockerCamelModel(pydantic.BaseModel):
-    class Config:
-        alias_generator = to_docker_camel
-
-        if PYDANTIC_V2:
-            populate_by_name = True
-        else:
+    if PYDANTIC_V2:
+        model_config = pydantic.ConfigDict(populate_by_name=True, alias_generator=to_docker_camel)
+    else:
+        class Config:
+            alias_generator = to_docker_camel
             allow_population_by_field_name = True
 
 

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -78,8 +78,12 @@ def to_docker_camel(string):
 
 class DockerCamelModel(pydantic.BaseModel):
     if PYDANTIC_V2:
-        model_config = pydantic.ConfigDict(populate_by_name=True, alias_generator=to_docker_camel)
+        model_config = pydantic.ConfigDict(
+            populate_by_name=True,
+            alias_generator=to_docker_camel,
+        )
     else:
+
         class Config:
             alias_generator = to_docker_camel
             allow_population_by_field_name = True


### PR DESCRIPTION
Got the following deprecation warning when running pytest on my project

```
../../../vscode/.local/lib/python3.11/site-packages/pydantic/_internal/_config.py:219
  /home/vscode/.local/lib/python3.11/site-packages/pydantic/_internal/_config.py:219: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.1.1/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
``` 

After doing some debugging, i found the root cause in `DockerCamelModel`. Defining a `Config` class is deprecated in v2, where it is replaced by a dict, or `pydantic.ConfigDict`. 

With this fix, one now should use the `ConfigDict` if V2 is used, and `Config` if V1 is used. It feels kinda hacky, but i guess thats what it takes to support both pydantic V1 and V2 :)