### PR TITLE
Documentation deployment doesn't work anymore

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocstrings==0.20.0
-mkdocstrings-python==1.0.0
+mkdocstrings-python==1.3.0
 mkdocs-autorefs==0.4.1
 mkdocs-material==9.1.14
 pymdown-extensions==10.0.1

--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -37,7 +37,7 @@ class ComposeCLI(DockerCLICaller):
             services: The services to build (as list of strings).
                 If `None` (default), all services are built.
                 An empty list means that nothing will be built.
-            build_arguments: Set build-time variables for services. For example
+            build_args: Set build-time variables for services. For example
                  `build_args={"PY_VERSION": "3.7.8", "UBUNTU_VERSION": "20.04"}`.
             cache: Set to `False` if you don't want to use the cache to build your images
             progress: Set type of progress output (auto, tty, plain, quiet) (default "auto")
@@ -96,7 +96,7 @@ class ComposeCLI(DockerCLICaller):
         build: bool = False,
         force_recreate: bool = False,
         no_build: bool = False,
-        no_recreate=False,
+        no_recreate: bool =False,
     ):
         """Creates containers for a service.
 
@@ -361,8 +361,8 @@ class ComposeCLI(DockerCLICaller):
         """Returns a list of docker compose projects
 
         Parameters:
-            all_stopped: Results include all stopped compose projects.
-            project_filters: Filter results based on conditions provided.
+            all: Results include all stopped compose projects.
+            filters: Filter results based on conditions provided.
 
         # Returns
             A `List[python_on_whales.ComposeProject]`

--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -96,7 +96,7 @@ class ComposeCLI(DockerCLICaller):
         build: bool = False,
         force_recreate: bool = False,
         no_build: bool = False,
-        no_recreate: bool =False,
+        no_recreate: bool = False,
     ):
         """Creates containers for a service.
 

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -972,7 +972,7 @@ class ContainerCLI(DockerCLICaller):
         """Returns a container object from a name or ID.
 
         Parameters:
-            reference: A container name or ID, or a list of container names
+            x: A container name or ID, or a list of container names
                 and/or IDs
 
         Returns:

--- a/python_on_whales/components/context/cli_wrapper.py
+++ b/python_on_whales/components/context/cli_wrapper.py
@@ -146,7 +146,7 @@ class ContextCLI(DockerCLICaller):
         """Creates a new context
 
         Parameters:
-            context: name of the context to create
+            context_name: name of the context to create
             default_stack_orchestrator: Default orchestrator for stack operations to use with this context (swarm|kubernetes|all)
             description: Description of the context
             docker: Set the docker endpoint, you can use a dict of a class to

--- a/python_on_whales/components/plugin/cli_wrapper.py
+++ b/python_on_whales/components/plugin/cli_wrapper.py
@@ -234,7 +234,7 @@ class PluginCLI(DockerCLICaller):
         """Removes one or more plugins
 
         Parameters:
-            plugin: One or more plugins to remove.
+            x: One or more plugins to remove.
             force: Force the removal of this plugin.
         """
         full_cmd = self.docker_cmd + ["plugin", "remove"]

--- a/python_on_whales/components/stack/cli_wrapper.py
+++ b/python_on_whales/components/stack/cli_wrapper.py
@@ -56,8 +56,8 @@ class StackCLI(DockerCLICaller):
         Parameters:
             name: The name of the stack to deploy. Mandatory.
             compose_files: One or more docker-compose files. If there are more than
-            one, they will be fused together.
-            orchestrator: The orchestrator to use, `"swarm" or "kubernetes" or "all".
+                one, they will be fused together.
+                orchestrator: The orchestrator to use, `"swarm" or "kubernetes" or "all".
             prune: Prune services that are no longer referenced
             resolve_image: Query the registry to resolve image digest
                 and supported platforms `"always"|"changed"|"never"` (default `"always"`).

--- a/python_on_whales/components/swarm/cli_wrapper.py
+++ b/python_on_whales/components/swarm/cli_wrapper.py
@@ -82,6 +82,8 @@ class SwarmCLI(DockerCLICaller):
             availability: Availability of the node ("active"|"pause"|"drain")
             data_path_address: Address or interface to use for data path
                 traffic (format is `<ip|interface>`)
+            listen_address: address upon which the node listens for inbound
+                swarm manager traffic (format: `<ip|interface>[:port]`)
         """
         full_cmd = self.docker_cmd + ["swarm", "init"]
         full_cmd.add_simple_arg("--advertise-addr", advertise_address)
@@ -110,7 +112,7 @@ class SwarmCLI(DockerCLICaller):
                 (`"active"`|`"pause"`|`"drain"`)
             data_path_address: Address or interface to use for data
                 path traffic (format: <ip|interface>)
-            listen-address: Listen address (format: <ip|interface>[:port])
+            listen_address: Listen address (format: <ip|interface>[:port])
                 (default 0.0.0.0:2377)
             token: Token for entry into the swarm, will determine if
                 the node enters the swarm as a manager or a worker.

--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -48,7 +48,7 @@ class DockerClient(DockerCLICaller):
         debug: Enable debug mode
         host: Daemon socket(s) to connect to
         log_level: Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")
-           (default "info")
+            (default "info")
         tls:  Use TLS; implied by `tlsverify`
         tlscacert: Trust certs signed only by this CA (default "~/.docker/ca.pem")
         compose_files: Docker compose yaml file


### PR DESCRIPTION
#485 

**Note:** I have included fixes for each of the warnings logged during the docs' build process. According to the warning messages, type annotations wouldn't show up for the specified vars unless the warnings were fixed.

This being my first PR I worked primarily via the advice given in the description of the original bug i.e. narrow down which commit broke the docs. I tried reverting each commit one at a time (after checking out v0.64.2) however the `RecursionError` would still occur. After taking a closer look at the stack trace, and also messing with the markdown file and noticing that the presence of the `identifier` (ex: `python_on_whales.docker_client.DockerClient`) would cause the issue, I focused my efforts towards looking at issues with the `mkdocstrings-python` package. I couldn't find much about `jinja2` breaking `mkdocs` (except for https://github.com/mkdocs/mkdocs/issues/2799), however I did find good amounts of discussion regarding `Griffe` causing issues (https://github.com/mkdocstrings/mkdocstrings/issues/382, and https://github.com/mkdocstrings/griffe/issues/79). According to the [changelog](https://github.com/mkdocstrings/python/blob/main/CHANGELOG.md), `mkdocstrings-python` enforced a version upper bound on `griffe` in version `1.3`, hence why I chose to bump to this particular version. I tried out 1.2 as well however still ran into the same issue. 