### PR TITLE
Allow the streaming of the docker.compose.pull logs

### DIFF
--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -361,6 +361,21 @@ def test_docker_compose_pull():
     docker.compose.pull(["busybox", "alpine"], quiet=True)
 
 
+def test_docker_compose_pull_stream():
+    try:
+        docker.image.remove("busybox")
+    except NoSuchImage:
+        pass
+    logs = list(docker.compose.pull("busybox", stream_logs=True))
+    assert len(logs) >= 3
+    logs_as_big_binary = b""
+    for log_type, log_value in logs:
+        assert log_type in ("stdout", "stderr")
+        logs_as_big_binary += log_value
+    assert b"busybox Pulled" in logs_as_big_binary
+    assert b"Pull complete" in logs_as_big_binary
+
+
 def test_docker_compose_pull_ignore_pull_failures():
     docker = DockerClient(
         compose_files=[


### PR DESCRIPTION
same as #496 but for compose.pull. The test will most probably fail but i couldn't run it locally. having some problem with the docker registry, so hopefully it will run on github action and i will update it to the expected output