### PR TITLE
Error docker.execute with str

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -261,7 +261,7 @@ class Container(ReloadableObjectFromJson):
 
     def execute(
         self,
-        command: Union[str, List[str]],
+        command: List[str],
         detach: bool = False,
         envs: Dict[str, str] = {},
         env_files: Union[ValidPath, List[ValidPath]] = [],
@@ -838,7 +838,7 @@ class ContainerCLI(DockerCLICaller):
     def execute(
         self,
         container: ValidContainer,
-        command: Union[str, List[str]],
+        command: List[str],
         detach: bool = False,
         envs: Dict[str, str] = {},
         env_files: Union[ValidPath, List[ValidPath]] = [],

--- a/python_on_whales/components/service/cli_wrapper.py
+++ b/python_on_whales/components/service/cli_wrapper.py
@@ -144,7 +144,7 @@ class ServiceCLI(DockerCLICaller):
     def create(
         self,
         image: str,
-        command: Union[str, List[str], None],
+        command: Optional[List[str]],
         cap_add: List[str] = [],
         cap_drop: List[str] = [],
         constraints: List[str] = [],


### PR DESCRIPTION
#463 

Getting rid of `str` annotations from `command` variables.  I did notice that the `execute` method for the `ContainerCLI` class explicitly asserts for the `command` var to be of `list` type and throws an appropriate exception message if it is not. I decided not to perform the same assertion within the `ComposeCLI` class's `execute` function and the `ServiceCLI` class's `create` function since `beartype` can be of value of here (see comments within #466) . However, I am open to feedback regarding this.