### PR TITLE
adding support for docker stack config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 docs/generated_sources
 docs/site
+
+# pycharm or other jetbrains ide
+.idea/

--- a/README.md
+++ b/README.md
@@ -185,6 +185,28 @@ docker.run(
 )
 ```
 
+----------
+
+
+```bash
+export MYVAR=somevar
+source ./.env
+docker stack config --compose-file docker-compose.yml,docker-compose.overrides.yml
+```
+
+becomes
+```python
+from python_on_whales import docker
+
+config = docker.stack.config(
+    ["docker-compose.yml", "docker-compose.overrides.yml"],
+    env_files=[".env"],
+    variables={"MYVAR": "somevar"}
+)
+
+for service in config.services.values():
+    docker.image.pull(service.image)
+```
 
 Any Docker object can be used as a context manager to ensure it's removed even if an exception occurs:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = { file = ["requirements.txt"] }
 test = [
   "pytest",
 ]
+yaml = [
+  "pyyaml>=6.0.1",
+]
 
 [project.urls]
 "Source" = "https://github.com/gabrieldemarmiesse/python-on-whales"

--- a/python_on_whales/components/stack/cli_wrapper.py
+++ b/python_on_whales/components/stack/cli_wrapper.py
@@ -108,6 +108,29 @@ class StackCLI(DockerCLICaller):
         variables: Optional[Dict[str, str]] = None,
         return_json: bool = False,
     ) -> Union[ComposeConfig, Dict[str, Any]]:
+        """Returns the final config file, after doing merges and interpolations.
+
+        Parameters:
+            compose_files: One or more docker-compose files.
+                If there is more than one, they will be merged.
+            env_files: Similar to `.env` files in docker-compose, load `variables` from `.env` files.
+                If both `env_files` and `variables` are used, `variables` have priority.
+            variables: A dict dictating by what to replace the variables declared in the
+                docker-compose files.
+                In the docker CLI, you would use environment variables for this.
+            return_json: If `False`, a `ComposeConfig` object will be returned, and you'll be able
+                to take advantage of your IDE autocompletion. If you want the full json output, you
+                may use `return_json`. In this case, you'll get lists and dicts corresponding to the
+                json response, unmodified. It may be useful if you just want to print the config or
+                want to access a field that was not in the `ComposeConfig` class.
+
+        # Returns
+            A `ComposeConfig` object if `return_json` is `False`, and a `dict` otherwise.
+
+        # Raises
+            DockerException: if there's an error in one of the compose_files.
+            ImportError: if module `pyyaml` is not installed.
+        """
         if not _HAS_YAML:
             raise ImportError(
                 "Install yaml dependencies for this function (ex: pip install python_on_whales[yaml])"

--- a/python_on_whales/components/stack/cli_wrapper.py
+++ b/python_on_whales/components/stack/cli_wrapper.py
@@ -3,13 +3,19 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-import yaml
-
 import python_on_whales.components.service.cli_wrapper
 import python_on_whales.components.task.cli_wrapper
 from python_on_whales.client_config import DockerCLICaller
 from python_on_whales.components.compose.models import ComposeConfig
 from python_on_whales.utils import ValidPath, read_env_files, run, to_list
+
+try:
+    import yaml
+
+    _HAS_YAML = True
+except ImportError:
+    yaml = None
+    _HAS_YAML = False
 
 
 class Stack:
@@ -102,6 +108,10 @@ class StackCLI(DockerCLICaller):
         variables: Optional[Dict[str, str]] = None,
         return_json: bool = False,
     ) -> Union[ComposeConfig, Dict[str, Any]]:
+        if not _HAS_YAML:
+            raise ImportError(
+                "Install yaml dependencies for this function (ex: pip install python_on_whales[yaml])"
+            )
         env_files = [] if env_files is None else env_files
         variables = {} if variables is None else variables
 

--- a/python_on_whales/components/stack/cli_wrapper.py
+++ b/python_on_whales/components/stack/cli_wrapper.py
@@ -104,8 +104,8 @@ class StackCLI(DockerCLICaller):
     def config(
         self,
         compose_files: Union[ValidPath, List[ValidPath]],
-        env_files: Optional[List[ValidPath]] = None,
-        variables: Optional[Dict[str, str]] = None,
+        env_files: List[ValidPath] = [],
+        variables: Dict[str, str] = {},
         return_json: bool = False,
     ) -> Union[ComposeConfig, Dict[str, Any]]:
         """Returns the final config file, after doing merges and interpolations.
@@ -135,8 +135,6 @@ class StackCLI(DockerCLICaller):
             raise ImportError(
                 "Install yaml dependencies for this function (ex: pip install python_on_whales[yaml])"
             )
-        env_files = [] if env_files is None else env_files
-        variables = {} if variables is None else variables
 
         full_cmd = self.docker_cmd + ["stack", "config"]
         full_cmd.add_args_list("--compose-file", compose_files)

--- a/python_on_whales/components/stack/cli_wrapper.py
+++ b/python_on_whales/components/stack/cli_wrapper.py
@@ -100,9 +100,8 @@ class StackCLI(DockerCLICaller):
         compose_files: Union[ValidPath, List[ValidPath]],
         env_files: Optional[List[ValidPath]] = None,
         variables: Optional[Dict[str, str]] = None,
-        return_json: bool = False
+        return_json: bool = False,
     ) -> Union[ComposeConfig, Dict[str, Any]]:
-
         env_files = [] if env_files is None else env_files
         variables = {} if variables is None else variables
 
@@ -112,7 +111,9 @@ class StackCLI(DockerCLICaller):
         env = read_env_files([Path(x) for x in env_files])
         env.update(variables)
 
-        result = yaml.safe_load(run(full_cmd, capture_stdout=True, return_stderr=False, env=env))
+        result = yaml.safe_load(
+            run(full_cmd, capture_stdout=True, return_stderr=False, env=env)
+        )
 
         if return_json:
             return result

--- a/python_on_whales/components/stack/cli_wrapper.py
+++ b/python_on_whales/components/stack/cli_wrapper.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -117,7 +116,7 @@ class StackCLI(DockerCLICaller):
 
         if return_json:
             return result
-        return ComposeConfig.model_validate(result)
+        return ComposeConfig(**result)
 
     def list(self) -> List[Stack]:
         """Returns a list of `python_on_whales.Stack`

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 tqdm
 typer>=0.4.1
 typing_extensions
+pyyaml >= 6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ requests
 tqdm
 typer>=0.4.1
 typing_extensions
-pyyaml >= 6.0.1

--- a/tests/python_on_whales/components/test_stack.py
+++ b/tests/python_on_whales/components/test_stack.py
@@ -158,7 +158,7 @@ def test_stack_config_variables():
 
     agent_service = config.services["agent"]
     expected = "hello-world"
-    assert agent_service.environment['SOME_OTHER_VARIABLE'] == expected
+    assert agent_service.environment["SOME_OTHER_VARIABLE"] == expected
 
 
 def test_stack_config_variables_return_json():
@@ -170,7 +170,7 @@ def test_stack_config_variables_return_json():
 
     agent_service = config["services"]["agent"]
     expected = "hello-world"
-    assert agent_service["environment"]['SOME_OTHER_VARIABLE'] == expected
+    assert agent_service["environment"]["SOME_OTHER_VARIABLE"] == expected
 
 
 def test_stack_config_envfiles(tmp_path: Path):
@@ -183,7 +183,7 @@ def test_stack_config_envfiles(tmp_path: Path):
 
     agent_service = config.services["agent"]
     expected = '"--tls=true"'
-    assert agent_service.environment['SOME_OTHER_VARIABLE'] == expected
+    assert agent_service.environment["SOME_OTHER_VARIABLE"] == expected
 
 
 def test_stack_config_envfiles_return_json(tmp_path: Path):
@@ -197,4 +197,4 @@ def test_stack_config_envfiles_return_json(tmp_path: Path):
 
     agent_service = config["services"]["agent"]
     expected = '"--tls=true"'
-    assert agent_service["environment"]['SOME_OTHER_VARIABLE'] == expected
+    assert agent_service["environment"]["SOME_OTHER_VARIABLE"] == expected

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest==7.*
 pytest-mock
 pytz
+pyyaml>=6.0.1


### PR DESCRIPTION
The `docker stack config` command returns a yaml content on stdout. We have to parse the yaml output, hence the new pyyaml requirement.

The parameter "return_json" like the `ComposeCLI.config` method.

+ a couple of tests

fix: #509 