### PR TITLE
Tidy up test/SA CI run

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,8 +10,8 @@ jobs:
   build-linux-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@master
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Setup
@@ -51,8 +51,8 @@ jobs:
           - pydantic==2.*
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@master
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Setup
@@ -66,8 +66,8 @@ jobs:
   build-linux-test-other:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@master
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Setup
@@ -80,8 +80,8 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@master
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Setup
@@ -99,8 +99,8 @@ jobs:
 #  build-macos:
 #    runs-on: macos-latest
 #    steps:
-#      - uses: actions/checkout@master
-#      - uses: actions/setup-python@master
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-python@v5
 #        with:
 #          python-version: 3.8
 #      - name: Setup

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,5 @@
 name: Run tests
 
-
 on:
   push:
     branches:
@@ -11,41 +10,26 @@ jobs:
   build-linux-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@master
       with:
         python-version: '3.8'
-    - name: Run all tests
+    - name: Setup
       run: |
-        cat /etc/docker/daemon.json
-        echo '{"insecure-registries" : [ "localhost:5000" ]}' | sudo tee /etc/docker/daemon.json
-        sudo service docker restart
-        sleep 2
-        docker info
-        pip install -e .
-        pip install -r ./lint-requirements.txt
+        pip install -U pip wheel
+        pip install -e ./
+        pip install -r lint-requirements.txt
+    - name: Run all checks
+      run: |
         flake8
         isort --check ./
         black --check ./
 
-  build-linux-test-with-binaries-other-tests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Run all tests
-      run: |
-        bash tests/ci-setup.sh
-        python -m pytest -v --durations=10 --ignore=tests/python_on_whales/components
-
-
-  build-linux-test-component:
+  build-linux-test:
     strategy:
       matrix:
         component:
-          - buildx
+          - buildx/
           - test_compose.py
           - test_config.py
           - test_container.py
@@ -66,71 +50,81 @@ jobs:
           - pydantic==2.*
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
         with:
           python-version: '3.8'
-      - name: Run test
+      - name: Setup
         run: |
-          bash tests/ci-setup.sh
+          ./scripts/ci-setup.sh
+          pip install -U pip wheel
+          pip install -e ./
+          pip install -r tests/test-requirements.txt
           pip install --upgrade ${{ matrix.pydantic-version }}
-          python -m pytest -v --durations=10 tests/python_on_whales/components/${{ matrix.component }}
+      - name: Run component tests
+        run: |
+          pytest -vv --durations=10 tests/python_on_whales/components/${{ matrix.component }}
+      - name: Run other tests
+        run: |
+          pytest -vv --durations=10 --ignore=tests/python_on_whales/components/
 
-  build-linux-test-without-any-binary:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Run all tests
-      run: |
-        cat /etc/docker/daemon.json
-        echo '{"insecure-registries" : [ "localhost:5000" ]}' | sudo tee /etc/docker/daemon.json
-        sudo service docker restart
-        sleep 2
-        docker info
-        python -m pip install -e .
-        python -m pip install -r ./tests/test-requirements.txt
-        python -m pytest -v --durations=10 ./tests/python_on_whales/components/buildx
+#  build-linux-test-without-any-binary:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@master
+#    - uses: actions/setup-python@master
+#      with:
+#        python-version: '3.8'
+#    - name: Setup
+#      run: |
+#        bash -x scripts/add-local-docker-registry.sh
+#        docker info
+#        pip install -U pip wheel
+#        pip install -e ./
+#        pip install -r tests/test-requirements.txt
+#    - name: Run buildx tests
+#      run: |
+#        pytest -vv --durations=10 tests/python_on_whales/components/buildx/
 
   build-windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@master
       with:
         python-version: 3.8
-    - name: prepare
+    - name: Setup
       run: |
-        python -m pip install -r tests/test-requirements.txt
-        python -m pip install -e .
-    - name: Run all tests
-      run: |
+        docker info
         docker run hello-world
-        python -m pytest -v ./tests/python_on_whales/components/test_volume.py::test_simple_volume
+        pip install -U pip wheel
+        pip install -e ./
+        pip install -r tests/test-requirements.txt
+    - name: Run single test
+      run: |
+        pytest -vv tests/python_on_whales/components/test_volume.py::test_simple_volume
 
 #  cost too much at the moment.
 #  build-macos:
 #    runs-on: macos-latest
 #    steps:
-#    - uses: actions/checkout@v2
-#    - name: Install docker
+#    - uses: actions/checkout@master
+#    - uses: actions/setup-python@master
+#      with:
+#        python-version: 3.8
+#    - name: Setup
 #      run: |
 #        mkdir -p ~/.docker/machine/cache
 #        curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
 #        brew install docker docker-machine
 #        docker-machine create --driver virtualbox default
 #        docker-machine env default
-#    - uses: actions/setup-python@v2
-#      with:
-#        python-version: 3.8
-#    - name: prepare
-#      run: |
+#        eval "$(docker-machine env default)"
+#        docker info
+#        docker run hello-world
+#        pip install -U pip wheel
+#        pip install -e ./
 #        pip install -r tests/test-requirements.txt
-#        pip install -e .
 #    - name: Run all tests
 #      run: |
-#        eval "$(docker-machine env default)"
-#        docker run hello-world
-#        pytest -v ./tests
+#        pytest -vv tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,20 +10,20 @@ jobs:
   build-linux-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@master
-      with:
-        python-version: '3.8'
-    - name: Setup
-      run: |
-        pip install -U pip wheel
-        pip install -e ./
-        pip install -r lint-requirements.txt
-    - name: Run all checks
-      run: |
-        flake8
-        isort --check ./
-        black --check ./
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+        with:
+          python-version: '3.8'
+      - name: Setup
+        run: |
+          pip install -U pip wheel
+          pip install -e ./
+          pip install -r lint-requirements.txt
+      - name: Run all checks
+        run: |
+          flake8
+          isort --check ./
+          black --check ./
 
   build-linux-test-component:
     strategy:
@@ -69,77 +69,77 @@ jobs:
   build-linux-test-other:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@master
-      with:
-        python-version: '3.8'
-    - name: Setup
-      run: |
-        ./scripts/ci-setup.sh
-        pip install -U pip wheel
-        pip install -e ./
-        pip install -r tests/test-requirements.txt
-    - name: Run tests
-      run: |
-        python -m pytest -vv --durations=10 --ignore=tests/python_on_whales/components/
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+        with:
+          python-version: '3.8'
+      - name: Setup
+        run: |
+          ./scripts/ci-setup.sh
+          pip install -U pip wheel
+          pip install -e ./
+          pip install -r tests/test-requirements.txt
+      - name: Run tests
+        run: |
+          python -m pytest -vv --durations=10 --ignore=tests/python_on_whales/components/
 
 #  build-linux-test-without-any-binary:
 #    runs-on: ubuntu-latest
 #    steps:
-#    - uses: actions/checkout@master
-#    - uses: actions/setup-python@master
-#      with:
-#        python-version: '3.8'
-#    - name: Setup
-#      run: |
-#        bash -x scripts/add-local-docker-registry.sh
-#        docker info
-#        pip install -U pip wheel
-#        pip install -e ./
-#        pip install -r tests/test-requirements.txt
-#    - name: Run buildx tests
-#      run: |
-#        python -m pytest -vv --durations=10 tests/python_on_whales/components/buildx/
+#      - uses: actions/checkout@master
+#      - uses: actions/setup-python@master
+#        with:
+#          python-version: '3.8'
+#      - name: Setup
+#        run: |
+#          bash -x scripts/add-local-docker-registry.sh
+#          docker info
+#          pip install -U pip wheel
+#          pip install -e ./
+#          pip install -r tests/test-requirements.txt
+#      - name: Run buildx tests
+#        run: |
+#          python -m pytest -vv --durations=10 tests/python_on_whales/components/buildx/
 
   build-windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@master
-      with:
-        python-version: 3.8
-    - name: Setup
-      run: |
-        docker info
-        docker run hello-world
-        pip install -U pip wheel
-        pip install -e ./
-        pip install -r tests/test-requirements.txt
-    - name: Run single test
-      run: |
-        python -m pytest -vv tests/python_on_whales/components/test_volume.py::test_simple_volume
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+        with:
+          python-version: 3.8
+      - name: Setup
+        run: |
+          docker info
+          docker run hello-world
+          pip install -U pip wheel
+          pip install -e ./
+          pip install -r tests/test-requirements.txt
+      - name: Run single test
+        run: |
+          python -m pytest -vv tests/python_on_whales/components/test_volume.py::test_simple_volume
 
 #  cost too much at the moment.
 #  build-macos:
 #    runs-on: macos-latest
 #    steps:
-#    - uses: actions/checkout@master
-#    - uses: actions/setup-python@master
-#      with:
-#        python-version: 3.8
-#    - name: Setup
-#      run: |
-#        mkdir -p ~/.docker/machine/cache
-#        curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
-#        brew install docker docker-machine
-#        docker-machine create --driver virtualbox default
-#        docker-machine env default
-#        eval "$(docker-machine env default)"
-#        docker info
-#        docker run hello-world
-#        pip install -U pip wheel
-#        pip install -e ./
-#        pip install -r tests/test-requirements.txt
-#    - name: Run all tests
-#      run: |
-#        python -m pytest -vv tests/
+#      - uses: actions/checkout@master
+#      - uses: actions/setup-python@master
+#        with:
+#          python-version: 3.8
+#      - name: Setup
+#        run: |
+#          mkdir -p ~/.docker/machine/cache
+#          curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
+#          brew install docker docker-machine
+#          docker-machine create --driver virtualbox default
+#          docker-machine env default
+#          eval "$(docker-machine env default)"
+#          docker info
+#          docker run hello-world
+#          pip install -U pip wheel
+#          pip install -e ./
+#          pip install -r tests/test-requirements.txt
+#      - name: Run all tests
+#        run: |
+#          python -m pytest -vv tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,11 +25,12 @@ jobs:
         isort --check ./
         black --check ./
 
-  build-linux-test:
+  build-linux-test-component:
     strategy:
+      fail-fast: false
       matrix:
         component:
-          - buildx/
+          - buildx
           - test_compose.py
           - test_config.py
           - test_container.py
@@ -61,12 +62,26 @@ jobs:
           pip install -e ./
           pip install -r tests/test-requirements.txt
           pip install --upgrade ${{ matrix.pydantic-version }}
-      - name: Run component tests
+      - name: Run tests
         run: |
-          pytest -vv --durations=10 tests/python_on_whales/components/${{ matrix.component }}
-      - name: Run other tests
-        run: |
-          pytest -vv --durations=10 --ignore=tests/python_on_whales/components/
+          python -m pytest -vv --durations=10 tests/python_on_whales/components/${{ matrix.component }}
+
+  build-linux-test-other:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@master
+      with:
+        python-version: '3.8'
+    - name: Setup
+      run: |
+        ./scripts/ci-setup.sh
+        pip install -U pip wheel
+        pip install -e ./
+        pip install -r tests/test-requirements.txt
+    - name: Run tests
+      run: |
+        python -m pytest -vv --durations=10 --ignore=tests/python_on_whales/components/
 
 #  build-linux-test-without-any-binary:
 #    runs-on: ubuntu-latest
@@ -84,7 +99,7 @@ jobs:
 #        pip install -r tests/test-requirements.txt
 #    - name: Run buildx tests
 #      run: |
-#        pytest -vv --durations=10 tests/python_on_whales/components/buildx/
+#        python -m pytest -vv --durations=10 tests/python_on_whales/components/buildx/
 
   build-windows:
     runs-on: windows-latest
@@ -102,7 +117,7 @@ jobs:
         pip install -r tests/test-requirements.txt
     - name: Run single test
       run: |
-        pytest -vv tests/python_on_whales/components/test_volume.py::test_simple_volume
+        python -m pytest -vv tests/python_on_whales/components/test_volume.py::test_simple_volume
 
 #  cost too much at the moment.
 #  build-macos:
@@ -127,4 +142,4 @@ jobs:
 #        pip install -r tests/test-requirements.txt
 #    - name: Run all tests
 #      run: |
-#        pytest -vv tests/
+#        python -m pytest -vv tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,9 +58,6 @@ jobs:
       - name: Setup
         run: |
           ./scripts/ci-setup.sh
-          pip install -U pip wheel
-          pip install -e ./
-          pip install -r tests/test-requirements.txt
           pip install --upgrade ${{ matrix.pydantic-version }}
       - name: Run tests
         run: |
@@ -76,9 +73,6 @@ jobs:
       - name: Setup
         run: |
           ./scripts/ci-setup.sh
-          pip install -U pip wheel
-          pip install -e ./
-          pip install -r tests/test-requirements.txt
       - name: Run tests
         run: |
           python -m pytest -vv --durations=10 --ignore=tests/python_on_whales/components/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -77,24 +77,6 @@ jobs:
         run: |
           python -m pytest -vv --durations=10 --ignore=tests/python_on_whales/components/
 
-#  build-linux-test-without-any-binary:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@master
-#      - uses: actions/setup-python@master
-#        with:
-#          python-version: '3.8'
-#      - name: Setup
-#        run: |
-#          bash -x scripts/add-local-docker-registry.sh
-#          docker info
-#          pip install -U pip wheel
-#          pip install -e ./
-#          pip install -r tests/test-requirements.txt
-#      - name: Run buildx tests
-#        run: |
-#          python -m pytest -vv --durations=10 tests/python_on_whales/components/buildx/
-
   build-windows:
     runs-on: windows-latest
     steps:

--- a/scripts/add-local-docker-registry.sh
+++ b/scripts/add-local-docker-registry.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cat /etc/docker/daemon.json
+echo '{"insecure-registries" : [ "localhost:5000" ]}' | sudo tee /etc/docker/daemon.json
+sudo service docker restart
+sleep 2

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -7,3 +7,7 @@ THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 "$THIS_DIR"/add-local-docker-registry.sh
 "$THIS_DIR"/download-docker-plugins.sh
 docker info
+
+pip install -U pip wheel
+pip install -e ./
+pip install -r tests/test-requirements.txt

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+"$THIS_DIR"/add-local-docker-registry.sh
+"$THIS_DIR"/download-docker-plugins.sh
+docker info

--- a/scripts/download-docker-plugins.sh
+++ b/scripts/download-docker-plugins.sh
@@ -1,12 +1,6 @@
-set -ex
+#!/usr/bin/env bash
 
-cat /etc/docker/daemon.json
-echo '{"insecure-registries" : [ "localhost:5000" ]}' | sudo tee /etc/docker/daemon.json
-sudo service docker restart
-sleep 2
-docker info
-python -m pip install -e .
-python -m pip install -r ./tests/test-requirements.txt
+set -e
 
 mkdir -p ~/.docker/cli-plugins/
 wget -q https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-linux-x86_64 -O ~/.docker/cli-plugins/docker-compose


### PR DESCRIPTION
- Split up CI setup script into separate responsibilities
- Tidy up use of "setup" phase for each run
- Comment out the no-binary run, since it wasn't actually running without binaries?
- Don't fail fast on the matrix run, so that all failures can be checked at once
- Use 'master' rather than fixed version for checkout and setup-python actions to avoid node warnings (old versions seem more likely to break than being on latest)
- Don't bother setting up docker for linting

Precursor to adding podman to the CI.