### PR TITLE
#518 Add platform option for pull

### DIFF
--- a/tests/python_on_whales/components/test_manifest.py
+++ b/tests/python_on_whales/components/test_manifest.py
@@ -24,13 +24,13 @@ def with_manifest():
 
 @pytest.fixture
 def with_platform_variant_manifest(request):
-    image_with_platform_variant = "arm64v8/busybox:1.35"
+    image_with_platform_variant = "arm32v7/busybox:1.35"
 
     def remove_docker_image():
         docker.image.remove(image_with_platform_variant)
 
     request.addfinalizer(remove_docker_image)
-    docker.image.pull(image_with_platform_variant, quiet=True)
+    docker.image.pull(image_with_platform_variant, quiet=True, platform="linux/arm/v7")
     return docker.image.inspect(image_with_platform_variant)
 
 
@@ -63,5 +63,5 @@ def test_manifest_annotate(with_manifest):
 
 def test_manifest_platform_variant(with_platform_variant_manifest):
     assert "linux" in repr(with_platform_variant_manifest.os)
-    assert "arm64" in repr(with_platform_variant_manifest.architecture)
-    assert "v8" in repr(with_platform_variant_manifest.variant)
+    assert "arm" in repr(with_platform_variant_manifest.architecture)
+    assert "v7" in repr(with_platform_variant_manifest.variant)


### PR DESCRIPTION
This also fixes the platform variant test case mentioned in  #518 

**docker pull --help**

```
Usage:  docker pull [OPTIONS] NAME[:TAG|@DIGEST]

Download an image from a registry

Aliases:
  docker image pull, docker pull

Options:
  -a, --all-tags                Download all tagged images in the repository
      --disable-content-trust   Skip image verification (default true)
      --platform string         Set platform if server is multi-platform capable
  -q, --quiet                   Suppress verbose output

```