### PR TITLE
Support test parameterisation by docker and podman, enable in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -61,7 +61,8 @@ jobs:
           pip install --upgrade ${{ matrix.pydantic-version }}
       - name: Run tests
         run: |
-          python -m pytest -vv --durations=10 tests/python_on_whales/components/${{ matrix.component }}
+          python -m pytest -vv --durations=10 --ctr-exe docker,podman \
+              tests/python_on_whales/components/${{ matrix.component }}
 
   build-linux-test-other:
     runs-on: ubuntu-latest

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -7,6 +7,7 @@ THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 "$THIS_DIR"/add-local-docker-registry.sh
 "$THIS_DIR"/download-docker-plugins.sh
 docker info
+podman info
 
 pip install -U pip wheel
 pip install -e ./

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,21 @@
+import logging
+import subprocess
 import tempfile
 import time
 from pathlib import Path
+from typing import Any, Dict, List, Mapping
 
 import pydantic
 import pytest
 
-from python_on_whales import docker
+from python_on_whales import DockerClient, docker
+
+logger = logging.getLogger(__name__)
+
+
+#
+# -----------------------------------------------------------------------------
+# Fixtures
 
 
 @pytest.fixture
@@ -57,10 +67,126 @@ def swarm_mode():
     time.sleep(1)
 
 
-def pytest_collection_modifyitems(config, items):
-    if pydantic.__version__.startswith("1"):
-        return
-    for item in items:
-        item.add_marker(
-            pytest.mark.filterwarnings("error::pydantic.PydanticDeprecatedSince20")
+#
+# -----------------------------------------------------------------------------
+# Pytest hooks
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Pytest hook for adding CLI options."""
+
+    # Python-on-whales args
+    pow_group = parser.getgroup("python-on-whales")
+    pow_group.addoption(
+        "--ctr-exe",
+        metavar="EXE",
+        help=(
+            "Comma-separated list of executables to run the tests with, "
+            "defaults to one/both of 'docker' and 'podman' (depending on which "
+            "is available)"
+        ),
+    )
+
+
+def _get_ctr_clients(ctr_exes: List[str], *, all_required: bool) -> List[DockerClient]:
+    ctr_clients: List[DockerClient] = []
+    unsupported_ctr_clients: Dict[str, DockerClient] = {}
+    for exe in ctr_exes:
+        client = DockerClient(client_call=[exe])
+        # Check the client is available by running '<client> --version'.
+        try:
+            version_output = subprocess.check_output([exe, "--version"], text=True)
+        except subprocess.CalledProcessError:
+            unsupported_ctr_clients[exe] = client
+            continue
+        # Check the daemon is running with '<client> version'.
+        try:
+            subprocess.check_call([exe, "version"], stdout=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
+            unsupported_ctr_clients[exe] = client
+            continue
+
+        ctr_clients.append(client)
+
+        # Deduce whether docker or podman from version output.
+        if "docker" in version_output.lower():
+            client.ctr_mgr = "docker"
+        elif "podman" in version_output.lower():
+            client.ctr_mgr = "podman"
+        else:
+            logger.warning(
+                f"Unrecognised container manager from '{exe} --version', "
+                "assuming docker"
+            )
+            client.ctr_mgr = "docker"
+
+    if unsupported_ctr_clients:
+        if all_required:
+            raise Exception(
+                "'<ctr_exe> --version' failed for the following required exes: "
+                + ",".join(unsupported_ctr_clients)
+            )
+        else:
+            logger.warning(
+                "Unable to run with ctr exes: %s", ",".join(unsupported_ctr_clients)
+            )
+        if len(ctr_clients) == 0:
+            raise Exception("No supported ctr exes found")
+
+    return ctr_clients
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # Filter warnings
+    if not pydantic.__version__.startswith("1"):
+        config.addinivalue_line(
+            "filterwarnings", "error::pydantic.PydanticDeprecatedSince20"
         )
+    # Register markers
+    config.addinivalue_line(
+        "markers",
+        "ctr_mgr(MGR, MGR, ...): Container managers supported by the test",
+    )
+    # Determine supported container managers.
+    if config.getoption("--ctr-exe") is None:
+        config.ctr_clients = _get_ctr_clients(
+            ["docker", "podman"],
+            all_required=False,
+        )
+    else:
+        config.ctr_clients = _get_ctr_clients(
+            config.getoption("--ctr-exe").split(","),
+            all_required=True,
+        )
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "ctr_client" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "ctr_client",
+            metafunc.config.ctr_clients,
+            ids=[
+                client.client_config.client_call[0]
+                for client in metafunc.config.ctr_clients
+            ],
+        )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: List[pytest.Item]
+) -> None:
+    # Find paramaterisations that don't make sense and remove them from
+    # the list of tests to be run.
+    remove_tests = []
+    for item in items:
+        assert isinstance(item, pytest.Function)
+        if not hasattr(item, "callspec"):
+            continue
+        test_params: Mapping[str, Any] = item.callspec.params
+        if "ctr_client" in test_params and (
+            marker := item.get_closest_marker("ctr_mgr")
+        ):
+            if test_params["ctr_client"].ctr_mgr not in marker.args[0]:
+                remove_tests.append(item)
+    logger.debug("Removing %d parameterised tests", len(remove_tests))
+    items[:] = [x for x in items if x not in remove_tests]

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -70,9 +70,7 @@ def test_filter_when_listing_old_signature(ctr_client: DockerClient):
 
     warning_message = str(warnings_emmitted.list[0].message)
     assert "docker.image.list({'reference': 'hello-world'}" in warning_message
-    assert (
-        "docker.image.list(filters={'reference': 'hello-world'}" in warning_message
-    )
+    assert "docker.image.list(filters={'reference': 'hello-world'}" in warning_message
     tags = set()
     for image in images_listed:
         for tag in image.repo_tags:

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -62,6 +62,7 @@ def test_filter_when_listing(ctr_client: DockerClient):
     assert tags == {"hello-world:latest"}
 
 
+@pytest.mark.ctr_mgr("docker")
 def test_filter_when_listing_old_signature(ctr_client: DockerClient):
     """Check backward compatibility"""
     ctr_client.pull(["hello-world", "busybox"])

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -281,6 +281,7 @@ def test_no_such_image_tag(ctr_client: DockerClient):
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
+@pytest.mark.ctr_mgr("docker")
 def test_exists(ctr_client: DockerClient):
     my_image = ctr_client.pull("busybox")
     assert my_image.exists()

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -31,7 +31,7 @@ def test_image_remove(ctr_client: DockerClient):
     ctr_client.image.remove(["busybox:1", "busybox:1.32"])
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_image_save_load(ctr_client: DockerClient, tmp_path: Path):
     tar_file = tmp_path / "dodo.tar"
     ctr_client.image.pull("busybox:1", quiet=True)
@@ -51,7 +51,7 @@ def test_save_iterator_bytes(ctr_client: DockerClient):
     assert i != 0
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_filter_when_listing(ctr_client: DockerClient):
     ctr_client.pull(["hello-world", "busybox"])
     images_listed = ctr_client.image.list(filters=dict(reference="hello-world"))
@@ -62,7 +62,7 @@ def test_filter_when_listing(ctr_client: DockerClient):
     assert tags == {"hello-world:latest"}
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_filter_when_listing_old_signature(ctr_client: DockerClient):
     """Check backward compatibility"""
     ctr_client.pull(["hello-world", "busybox"])
@@ -79,7 +79,7 @@ def test_filter_when_listing_old_signature(ctr_client: DockerClient):
     assert tags == {"hello-world:latest"}
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_use_first_argument_to_filter(ctr_client: DockerClient):
     """Check backward compatibility"""
     ctr_client.pull(["hello-world", "busybox"])
@@ -91,7 +91,7 @@ def test_use_first_argument_to_filter(ctr_client: DockerClient):
     assert tags == {"hello-world:latest"}
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
     image_name = "busybox:1"
     ctr_client.image.pull(image_name, quiet=True)
@@ -106,7 +106,7 @@ def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
     ctr_client.image.inspect(image_name)
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
     image_name = "busybox:1"
     ctr_client.image.pull(image_name, quiet=True)
@@ -116,7 +116,7 @@ def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
     ctr_client.image.inspect(image_name)
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_save_iterator_bytes_and_load_from_iterator_list_of_images(
     ctr_client: DockerClient,
 ):
@@ -137,7 +137,7 @@ def test_image_list(ctr_client: DockerClient):
     assert len(set(all_ids_uniquified)) == len(image_list)
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_image_list_tags(ctr_client: DockerClient):
     image_name = "busybox:1"
     ctr_client.image.pull(image_name, quiet=True)
@@ -149,7 +149,7 @@ def test_image_list_tags(ctr_client: DockerClient):
         raise ValueError("Tag not found in images.")
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_pull_not_quiet(ctr_client: DockerClient):
     try:
         ctr_client.image.remove("busybox:1")
@@ -159,7 +159,7 @@ def test_pull_not_quiet(ctr_client: DockerClient):
     assert "busybox:1" in image.repo_tags
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_pull_not_quiet_multiple_images(ctr_client: DockerClient):
     images_names = ["busybox:1", "hello-world:latest"]
     try:
@@ -171,7 +171,7 @@ def test_pull_not_quiet_multiple_images(ctr_client: DockerClient):
         assert image_name in image.repo_tags
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_pull_not_quiet_multiple_images_break(ctr_client: DockerClient):
     images_names = ["busybox:1", "hellstuff"]
     try:
@@ -209,7 +209,7 @@ def test_copy_from_and_to_directory(ctr_client: DockerClient, tmp_path: Path):
     assert "Hello world!" == (tmp_path / "some_path" / "dodo.txt").read_text()
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_prune(ctr_client: DockerClient):
     ctr_client.pull("busybox")
     ctr_client.image.prune(all=True)
@@ -217,7 +217,7 @@ def test_prune(ctr_client: DockerClient):
         ctr_client.image.inspect("busybox")
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_remove_nothing(ctr_client: DockerClient):
     with ctr_client.pull("hello-world"):
         all_images = set(ctr_client.image.list())
@@ -225,7 +225,7 @@ def test_remove_nothing(ctr_client: DockerClient):
         assert all_images == set(ctr_client.image.list())
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_no_such_image_inspect(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
@@ -234,7 +234,7 @@ def test_no_such_image_inspect(ctr_client: DockerClient):
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_no_such_image_remove(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
@@ -243,7 +243,7 @@ def test_no_such_image_remove(ctr_client: DockerClient):
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_no_such_image_push(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
@@ -252,7 +252,7 @@ def test_no_such_image_push(ctr_client: DockerClient):
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_no_such_image_save(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
@@ -261,7 +261,7 @@ def test_no_such_image_save(ctr_client: DockerClient):
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_no_such_image_save_generator(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
@@ -271,7 +271,7 @@ def test_no_such_image_save_generator(ctr_client: DockerClient):
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_no_such_image_tag(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
@@ -280,7 +280,7 @@ def test_no_such_image_tag(ctr_client: DockerClient):
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-@pytest.mark.ctr_mgr("docker")
+@pytest.mark.ctr_mgr("docker", skip=True)
 def test_exists(ctr_client: DockerClient):
     my_image = ctr_client.pull("busybox")
     assert my_image.exists()

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -69,9 +69,9 @@ def test_filter_when_listing_old_signature(ctr_client: DockerClient):
         images_listed = ctr_client.image.list({"reference": "hello-world"})
 
     warning_message = str(warnings_emmitted.list[0].message)
-    assert "ctr_client.image.list({'reference': 'hello-world'}" in warning_message
+    assert "docker.image.list({'reference': 'hello-world'}" in warning_message
     assert (
-        "ctr_client.image.list(filters={'reference': 'hello-world'}" in warning_message
+        "docker.image.list(filters={'reference': 'hello-world'}" in warning_message
     )
     tags = set()
     for image in images_listed:

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -1,9 +1,10 @@
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from python_on_whales import docker
+from python_on_whales import DockerClient, docker
 from python_on_whales.components.image.models import ImageInspectResult
 from python_on_whales.exceptions import DockerException, NoSuchImage
 from python_on_whales.test_utils import get_all_jsons, random_name
@@ -16,31 +17,32 @@ def test_load_json(json_file):
     # we could do more checks here if needed
 
 
-def test_image_repr():
-    docker.image.pull("busybox:1", quiet=True)
-    docker.image.pull("busybox:1.32", quiet=True)
-    assert "busybox:1" in repr(docker.image.list())
-    assert "busybox:1.32" in repr(docker.image.list())
-    docker.image.remove(["busybox:1", "busybox:1.32"])
+def test_image_repr(ctr_client: DockerClient):
+    ctr_client.image.pull("busybox:1", quiet=True)
+    ctr_client.image.pull("busybox:1.32", quiet=True)
+    assert "busybox:1" in repr(ctr_client.image.list())
+    assert "busybox:1.32" in repr(ctr_client.image.list())
+    ctr_client.image.remove(["busybox:1", "busybox:1.32"])
 
 
-def test_image_remove():
-    docker.image.pull("busybox:1", quiet=True)
-    docker.image.pull("busybox:1.32", quiet=True)
-    docker.image.remove(["busybox:1", "busybox:1.32"])
+def test_image_remove(ctr_client: DockerClient):
+    ctr_client.image.pull("busybox:1", quiet=True)
+    ctr_client.image.pull("busybox:1.32", quiet=True)
+    ctr_client.image.remove(["busybox:1", "busybox:1.32"])
 
 
-def test_image_save_load(tmp_path):
+@pytest.mark.ctr_mgr("docker")
+def test_image_save_load(ctr_client: DockerClient, tmp_path: Path):
     tar_file = tmp_path / "dodo.tar"
-    docker.image.pull("busybox:1", quiet=True)
-    docker.image.save("busybox:1", output=tar_file)
-    docker.image.remove("busybox:1")
-    assert docker.image.load(input=tar_file) == ["busybox:1"]
+    ctr_client.image.pull("busybox:1", quiet=True)
+    ctr_client.image.save("busybox:1", output=tar_file)
+    ctr_client.image.remove("busybox:1")
+    assert ctr_client.image.load(input=tar_file) == ["busybox:1"]
 
 
-def test_save_iterator_bytes():
-    docker.image.pull("busybox:1", quiet=True)
-    iterator = docker.image.save("busybox:1")
+def test_save_iterator_bytes(ctr_client: DockerClient):
+    ctr_client.image.pull("busybox:1", quiet=True)
+    iterator = ctr_client.image.save("busybox:1")
 
     for i, my_bytes in enumerate(iterator):
         if i == 0:
@@ -49,9 +51,10 @@ def test_save_iterator_bytes():
     assert i != 0
 
 
-def test_filter_when_listing():
-    docker.pull(["hello-world", "busybox"])
-    images_listed = docker.image.list(filters=dict(reference="hello-world"))
+@pytest.mark.ctr_mgr("docker")
+def test_filter_when_listing(ctr_client: DockerClient):
+    ctr_client.pull(["hello-world", "busybox"])
+    images_listed = ctr_client.image.list(filters=dict(reference="hello-world"))
     tags = set()
     for image in images_listed:
         for tag in image.repo_tags:
@@ -59,15 +62,17 @@ def test_filter_when_listing():
     assert tags == {"hello-world:latest"}
 
 
-def test_filter_when_listing_old_signature():
+def test_filter_when_listing_old_signature(ctr_client: DockerClient):
     """Check backward compatibility"""
-    docker.pull(["hello-world", "busybox"])
+    ctr_client.pull(["hello-world", "busybox"])
     with pytest.warns(DeprecationWarning) as warnings_emmitted:
-        images_listed = docker.image.list({"reference": "hello-world"})
+        images_listed = ctr_client.image.list({"reference": "hello-world"})
 
     warning_message = str(warnings_emmitted.list[0].message)
-    assert "docker.image.list({'reference': 'hello-world'}" in warning_message
-    assert "docker.image.list(filters={'reference': 'hello-world'}" in warning_message
+    assert "ctr_client.image.list({'reference': 'hello-world'}" in warning_message
+    assert (
+        "ctr_client.image.list(filters={'reference': 'hello-world'}" in warning_message
+    )
     tags = set()
     for image in images_listed:
         for tag in image.repo_tags:
@@ -75,10 +80,11 @@ def test_filter_when_listing_old_signature():
     assert tags == {"hello-world:latest"}
 
 
-def test_use_first_argument_to_filter():
+@pytest.mark.ctr_mgr("docker")
+def test_use_first_argument_to_filter(ctr_client: DockerClient):
     """Check backward compatibility"""
-    docker.pull(["hello-world", "busybox"])
-    images_listed = docker.image.list("hello-world")
+    ctr_client.pull(["hello-world", "busybox"])
+    images_listed = ctr_client.image.list("hello-world")
     tags = set()
     for image in images_listed:
         for tag in image.repo_tags:
@@ -86,55 +92,57 @@ def test_use_first_argument_to_filter():
     assert tags == {"hello-world:latest"}
 
 
-def test_save_iterator_bytes_and_load():
+@pytest.mark.ctr_mgr("docker")
+def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
     image_name = "busybox:1"
-    docker.image.pull(image_name, quiet=True)
-    iterator = docker.image.save(image_name)
+    ctr_client.image.pull(image_name, quiet=True)
+    iterator = ctr_client.image.save(image_name)
 
     my_tar_as_bytes = b"".join(iterator)
 
-    docker.image.remove(image_name)
+    ctr_client.image.remove(image_name)
 
-    loaded = docker.image.load(my_tar_as_bytes)
+    loaded = ctr_client.image.load(my_tar_as_bytes)
     assert loaded == [image_name]
-    docker.image.inspect(image_name)
+    ctr_client.image.inspect(image_name)
 
 
-def test_save_iterator_bytes_and_load_from_iterator():
+@pytest.mark.ctr_mgr("docker")
+def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
     image_name = "busybox:1"
-    docker.image.pull(image_name, quiet=True)
-    iterator = docker.image.save(image_name)
+    ctr_client.image.pull(image_name, quiet=True)
+    iterator = ctr_client.image.save(image_name)
 
-    assert docker.image.load(iterator) == [image_name]
-    docker.image.inspect(image_name)
+    assert ctr_client.image.load(iterator) == [image_name]
+    ctr_client.image.inspect(image_name)
 
 
-def test_save_iterator_bytes_and_load_from_iterator_list_of_images():
+@pytest.mark.ctr_mgr("docker")
+def test_save_iterator_bytes_and_load_from_iterator_list_of_images(
+    ctr_client: DockerClient,
+):
     images = ["busybox:1", "hello-world:latest"]
-    docker.image.pull(images[0], quiet=True)
-    docker.image.pull(images[1], quiet=True)
-    iterator = docker.image.save(images)
+    ctr_client.image.pull(images[0], quiet=True)
+    ctr_client.image.pull(images[1], quiet=True)
+    iterator = ctr_client.image.save(images)
 
-    assert set(docker.image.load(iterator)) == set(images)
-    docker.image.inspect(images[0])
-    docker.image.inspect(images[1])
+    assert set(ctr_client.image.load(iterator)) == set(images)
+    ctr_client.image.inspect(images[0])
+    ctr_client.image.inspect(images[1])
 
 
-def test_image_list():
-    image_list = docker.image.list()
+def test_image_list(ctr_client: DockerClient):
+    image_list = ctr_client.image.list()
     all_ids = [x.id for x in image_list]
     all_ids_uniquified = set(all_ids)
     assert len(set(all_ids_uniquified)) == len(image_list)
 
 
-def test_image_bulk_reload():
-    pass
-
-
-def test_image_list_tags():
+@pytest.mark.ctr_mgr("docker")
+def test_image_list_tags(ctr_client: DockerClient):
     image_name = "busybox:1"
-    docker.image.pull(image_name, quiet=True)
-    all_images = docker.image.list()
+    ctr_client.image.pull(image_name, quiet=True)
+    all_images = ctr_client.image.list()
     for image in all_images:
         if image_name in image.repo_tags:
             return
@@ -142,119 +150,143 @@ def test_image_list_tags():
         raise ValueError("Tag not found in images.")
 
 
-def test_pull_not_quiet():
+@pytest.mark.ctr_mgr("docker")
+def test_pull_not_quiet(ctr_client: DockerClient):
     try:
-        docker.image.remove("busybox:1")
+        ctr_client.image.remove("busybox:1")
     except DockerException:
         pass
-    image = docker.image.pull("busybox:1")
+    image = ctr_client.image.pull("busybox:1")
     assert "busybox:1" in image.repo_tags
 
 
-def test_pull_not_quiet_multiple_images():
+@pytest.mark.ctr_mgr("docker")
+def test_pull_not_quiet_multiple_images(ctr_client: DockerClient):
     images_names = ["busybox:1", "hello-world:latest"]
     try:
-        docker.image.remove(images_names)
+        ctr_client.image.remove(images_names)
     except DockerException:
         pass
-    images = docker.pull(images_names)
+    images = ctr_client.pull(images_names)
     for image_name, image in zip(images_names, images):
         assert image_name in image.repo_tags
 
 
-def test_pull_not_quiet_multiple_images_break():
+@pytest.mark.ctr_mgr("docker")
+def test_pull_not_quiet_multiple_images_break(ctr_client: DockerClient):
     images_names = ["busybox:1", "hellstuff"]
     try:
-        docker.image.remove(images_names)
+        ctr_client.image.remove(images_names)
     except DockerException:
         pass
 
     with pytest.raises(DockerException) as err:
-        docker.pull(images_names)
+        ctr_client.pull(images_names)
 
     assert "docker image pull hellstuff" in str(err.value)
 
 
-def test_copy_from_and_to(tmp_path):
-    my_image = docker.pull("busybox:1")
+def test_copy_from_and_to(ctr_client: DockerClient, tmp_path: Path):
+    my_image = ctr_client.pull("busybox:1")
     (tmp_path / "dodo.txt").write_text("Hello world!")
 
     new_image_name = random_name()
     my_image.copy_to(tmp_path / "dodo.txt", "/dada.txt", new_tag=new_image_name)
 
-    new_image_name = docker.image.inspect(new_image_name)
+    new_image_name = ctr_client.image.inspect(new_image_name)
     new_image_name.copy_from("/dada.txt", tmp_path / "dudu.txt")
     assert (tmp_path / "dodo.txt").read_text() == (tmp_path / "dudu.txt").read_text()
 
 
-def test_copy_from_and_to_directory(tmp_path):
-    my_image = docker.pull("busybox:1")
+def test_copy_from_and_to_directory(ctr_client: DockerClient, tmp_path: Path):
+    my_image = ctr_client.pull("busybox:1")
     (tmp_path / "dodo.txt").write_text("Hello world!")
 
     new_image_name = random_name()
     my_image.copy_to(tmp_path, "/some_path", new_tag=new_image_name)
 
-    new_image_name = docker.image.inspect(new_image_name)
+    new_image_name = ctr_client.image.inspect(new_image_name)
     new_image_name.copy_from("/some_path", tmp_path / "some_path")
     assert "Hello world!" == (tmp_path / "some_path" / "dodo.txt").read_text()
 
 
-def test_prune():
-    docker.pull("busybox")
-    docker.image.prune(all=True)
+@pytest.mark.ctr_mgr("docker")
+def test_prune(ctr_client: DockerClient):
+    ctr_client.pull("busybox")
+    ctr_client.image.prune(all=True)
     with pytest.raises(DockerException):
-        docker.image.inspect("busybox")
+        ctr_client.image.inspect("busybox")
 
 
-def test_remove_nothing():
-    with docker.pull("hello-world"):
-        all_images = set(docker.image.list())
-        docker.image.remove([])
-        assert all_images == set(docker.image.list())
+@pytest.mark.ctr_mgr("docker")
+def test_remove_nothing(ctr_client: DockerClient):
+    with ctr_client.pull("hello-world"):
+        all_images = set(ctr_client.image.list())
+        ctr_client.image.remove([])
+        assert all_images == set(ctr_client.image.list())
 
 
-@pytest.mark.parametrize(
-    "docker_function", [docker.image.inspect, docker.image.remove, docker.push]
-)
-def test_no_such_image_with_multiple_functions(docker_function):
+@pytest.mark.ctr_mgr("docker")
+def test_no_such_image_inspect(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
-        docker_function(image_name_that_does_not_exists)
+        ctr_client.image.inspect(image_name_that_does_not_exists)
 
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-def test_no_such_image_save():
+@pytest.mark.ctr_mgr("docker")
+def test_no_such_image_remove(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
-        docker.image.save(image_name_that_does_not_exists, output="/tmp/dada")
+        ctr_client.image.remove(image_name_that_does_not_exists)
 
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-def test_no_such_image_save_generator():
+@pytest.mark.ctr_mgr("docker")
+def test_no_such_image_push(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
-        for _ in docker.image.save(image_name_that_does_not_exists):
+        ctr_client.push(image_name_that_does_not_exists)
+
+    assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
+
+
+@pytest.mark.ctr_mgr("docker")
+def test_no_such_image_save(ctr_client: DockerClient):
+    image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
+    with pytest.raises(NoSuchImage) as err:
+        ctr_client.image.save(image_name_that_does_not_exists, output="/tmp/dada")
+
+    assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
+
+
+@pytest.mark.ctr_mgr("docker")
+def test_no_such_image_save_generator(ctr_client: DockerClient):
+    image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
+    with pytest.raises(NoSuchImage) as err:
+        for _ in ctr_client.image.save(image_name_that_does_not_exists):
             pass
 
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-def test_no_such_image_tag():
+@pytest.mark.ctr_mgr("docker")
+def test_no_such_image_tag(ctr_client: DockerClient):
     image_name_that_does_not_exists = "dueizhguizhfezaezagrthyh"
     with pytest.raises(NoSuchImage) as err:
-        docker.image.tag(image_name_that_does_not_exists, "something")
+        ctr_client.image.tag(image_name_that_does_not_exists, "something")
 
     assert f"No such image: {image_name_that_does_not_exists}" in str(err.value)
 
 
-def test_exists():
-    my_image = docker.pull("busybox")
+def test_exists(ctr_client: DockerClient):
+    my_image = ctr_client.pull("busybox")
     assert my_image.exists()
-    assert docker.image.exists("busybox")
+    assert ctr_client.image.exists("busybox")
 
-    assert not docker.image.exists("dudurghurozgiozpfezjigfoeioengizeonig")
+    assert not ctr_client.image.exists("dudurghurozgiozpfezjigfoeioengizeonig")
 
 
 @patch("python_on_whales.components.image.cli_wrapper.ContainerCLI")


### PR DESCRIPTION
- `pytest tests/` - run tests with docker, also with podman if available
- `pytest tests/ --ctr-exe docker` - run tests with docker only
- `pytest tests/ --ctr-exe podman` - run tests with podman only
- `pytest tests/ --ctr-exe docker,podman` - explicitly run tests with both docker and podman (for use in the CI)
- Also supports non-standard exe names and detects whether docker/podman, e.g. `pytest tests/ --ctr-exe podman4.2`

With the default, which checks whether docker and podman are available before parameterising on both:
```
(venv) python-on-whales/(podman-CI)$python -m pytest tests/python_on_whales/components/test_image.py -k test_filter_when_listing_old_signature -vv
=============================================== test session starts ================================================
platform linux -- Python 3.9.5, pytest-7.1.2, pluggy-1.0.0 -- /mnt/c/Users/legaul/repos/python-on-whales/venv/bin/python
cachedir: .pytest_cache
rootdir: /mnt/c/Users/legaul/repos/python-on-whales
plugins: mock-3.8.2
collected 66 items / 64 deselected / 2 selected

tests/python_on_whales/components/test_image.py::test_filter_when_listing_old_signature[docker] PASSED       [ 50%]
tests/python_on_whales/components/test_image.py::test_filter_when_listing_old_signature[podman] SKIPPED (Not supported with podman) [100%]

=================================== 1 passed, 1 skipped, 64 deselected in 1.46s ====================================
```

Specifying only docker:
```
(venv) python-on-whales/(podman-CI)$python -m pytest tests/python_on_whales/components/test_image.py -k test_filter_when_listing_old_signature -vv --ctr-exe docker
=============================================== test session starts ================================================
platform linux -- Python 3.9.5, pytest-7.1.2, pluggy-1.0.0 -- /mnt/c/Users/legaul/repos/python-on-whales/venv/bin/python
cachedir: .pytest_cache
rootdir: /mnt/c/Users/legaul/repos/python-on-whales
plugins: mock-3.8.2
collected 40 items / 39 deselected / 1 selected

tests/python_on_whales/components/test_image.py::test_filter_when_listing_old_signature[docker] PASSED       [100%]

========================================= 1 passed, 39 deselected in 1.54s =========================================
```