### PR TITLE
Introduce `ctr_client` fixture, add `--ctr-exe` CLI arg

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
+from typing import Generator
 
 import pydantic
 import pytest
@@ -46,12 +47,12 @@ def ctr_client(pytestconfig: pytest.Config) -> DockerClient:
     return client
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def docker_registry(ctr_client: DockerClient):
     yield from _docker_registry(ctr_client)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def docker_registry_without_login(ctr_client: DockerClient):
     yield from _docker_registry(ctr_client, login=False)
 
@@ -87,8 +88,8 @@ def _docker_registry(ctr_client: DockerClient, login=True):
             yield "localhost:5000"
 
 
-@pytest.fixture(scope="session")
-def swarm_mode(ctr_client: DockerClient):
+@pytest.fixture(scope="function")
+def swarm_mode(ctr_client: DockerClient) -> Generator[None, None, None]:
     ctr_client.swarm.init()
     yield
     ctr_client.swarm.leave(force=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 import tempfile
 import time
@@ -8,10 +9,13 @@ import pytest
 
 from python_on_whales import DockerClient
 
+logger = logging.getLogger(__name__)
+
 
 @pytest.fixture(scope="session")
 def ctr_client(pytestconfig: pytest.Config) -> DockerClient:
     ctr_exe = pytestconfig.getoption("--ctr-exe")
+    logger.info("Running tests with container exe: %s", ctr_exe)
     client = DockerClient(client_call=[ctr_exe])
     # Check the client is available.
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import subprocess
 import tempfile
 import time
 from pathlib import Path
@@ -5,21 +6,54 @@ from pathlib import Path
 import pydantic
 import pytest
 
-from python_on_whales import docker
+from python_on_whales import DockerClient
 
 
-@pytest.fixture
-def docker_registry():
-    yield from _docker_registry()
+@pytest.fixture(scope="session")
+def ctr_client(pytestconfig: pytest.Config) -> DockerClient:
+    ctr_exe = pytestconfig.getoption("--ctr-exe")
+    client = DockerClient(client_call=[ctr_exe])
+    # Check the client is available.
+    try:
+        # TODO: Implement 'DockerClient.version' and use that instead.
+        subprocess.run(
+            [ctr_exe, "version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ) as exc:
+        if isinstance(exc, subprocess.CalledProcessError):
+            reason = "\n" + exc.output
+        elif isinstance(exc, subprocess.TimeoutExpired):
+            reason = f"timed out after {exc.timeout} seconds"
+        elif isinstance(exc, FileNotFoundError):
+            reason = f"executable not found"
+        raise RuntimeError(
+            f"Unable to run with container exe {ctr_exe!r}.\n"
+            f"'{ctr_exe} version' command failed: {reason}"
+        ) from exc
+    return client
 
 
-@pytest.fixture
-def docker_registry_without_login():
-    yield from _docker_registry(login=False)
+@pytest.fixture(scope="session")
+def docker_registry(ctr_client: DockerClient):
+    yield from _docker_registry(ctr_client)
 
 
-def _docker_registry(login=True):
-    encrypted_password = docker.run(
+@pytest.fixture(scope="session")
+def docker_registry_without_login(ctr_client: DockerClient):
+    yield from _docker_registry(ctr_client, login=False)
+
+
+def _docker_registry(ctr_client: DockerClient, login=True):
+    encrypted_password = ctr_client.run(
         "mhenry07/apache2-utils",
         ["htpasswd", "-Bbn", "my_user", "my_password"],
         remove=True,
@@ -28,7 +62,7 @@ def _docker_registry(login=True):
         tmp_path = Path(tmp_path)
         htpasswd_file = tmp_path / "htpasswd"
         htpasswd_file.write_text(encrypted_password)
-        registry = docker.container.create(
+        registry = ctr_client.container.create(
             "registry:2",
             remove=True,
             envs=dict(
@@ -43,24 +77,34 @@ def _docker_registry(login=True):
             registry.start()
             time.sleep(1.5)
             if login:
-                docker.login(
+                ctr_client.login(
                     "localhost:5000", username="my_user", password="my_password"
                 )
             yield "localhost:5000"
 
 
-@pytest.fixture
-def swarm_mode():
-    docker.swarm.init()
+@pytest.fixture(scope="session")
+def swarm_mode(ctr_client: DockerClient):
+    ctr_client.swarm.init()
     yield
-    docker.swarm.leave(force=True)
+    ctr_client.swarm.leave(force=True)
     time.sleep(1)
 
 
-def pytest_collection_modifyitems(config, items):
-    if pydantic.__version__.startswith("1"):
-        return
-    for item in items:
-        item.add_marker(
-            pytest.mark.filterwarnings("error::pydantic.PydanticDeprecatedSince20")
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Pytest hook for adding CLI options."""
+    pow_group = parser.getgroup("python-on-whales")
+    pow_group.addoption(
+        "--ctr-exe",
+        metavar="EXE",
+        default="docker",
+        help="Container executable to run the tests with, defaults to using docker",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # Filter warnings
+    if not pydantic.__version__.startswith("1"):
+        config.addinivalue_line(
+            "filterwarnings", "error::pydantic.PydanticDeprecatedSince20"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def ctr_client(pytestconfig: pytest.Config) -> DockerClient:
         elif isinstance(exc, subprocess.TimeoutExpired):
             reason = f"timed out after {exc.timeout} seconds"
         elif isinstance(exc, FileNotFoundError):
-            reason = f"executable not found"
+            reason = "executable not found"
         raise RuntimeError(
             f"Unable to run with container exe {ctr_exe!r}.\n"
             f"'{ctr_exe} version' command failed: {reason}"

--- a/tests/python_on_whales/components/test_node.py
+++ b/tests/python_on_whales/components/test_node.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from python_on_whales import docker
+from python_on_whales import DockerClient
 from python_on_whales.components.node.models import NodeInspectResult
 from python_on_whales.test_utils import get_all_jsons
 
@@ -24,40 +24,40 @@ def test_load_json(json_file):
 
 
 @pytest.mark.usefixtures("swarm_mode")
-def test_list_nodes():
-    nodes = docker.node.list()
+def test_list_nodes(ctr_client: DockerClient):
+    nodes = ctr_client.node.list()
     assert nodes[0].id[:12] in repr(nodes)
     assert len(nodes) == 1
 
 
 @pytest.mark.usefixtures("swarm_mode")
-def test_add_label():
-    nodes = docker.node.list()
+def test_add_label(ctr_client: DockerClient):
+    nodes = ctr_client.node.list()
     nodes[0].update(labels_add={"foo": "bar"})
     assert nodes[0].spec.labels["foo"] == "bar"
 
 
 @pytest.mark.usefixtures("swarm_mode")
-def test_remove_label():
-    nodes = docker.node.list()
+def test_remove_label(ctr_client: DockerClient):
+    nodes = ctr_client.node.list()
     nodes[0].update(labels_add={"foo": "bar"})
     nodes[0].update(rm_labels=["foo"])
     assert "foo" not in nodes[0].spec.labels
 
 
 @pytest.mark.usefixtures("swarm_mode")
-def test_tasks():
-    service = docker.service.create("busybox", ["sleep", "infinity"])
+def test_tasks(ctr_client: DockerClient):
+    service = ctr_client.service.create("busybox", ["sleep", "infinity"])
 
-    current_node = docker.node.list()[0]
+    current_node = ctr_client.node.list()[0]
     tasks = current_node.ps()
     assert len(tasks) > 0
     assert tasks[0].desired_state == "running"
-    docker.service.remove(service)
+    ctr_client.service.remove(service)
 
 
 @pytest.mark.usefixtures("swarm_mode")
-def test_list_tasks_node():
-    with docker.service.create("busybox", ["sleep", "infinity"]) as my_service:
-        assert docker.node.ps([]) == []
-        assert set(docker.node.ps()) == set(docker.service.ps(my_service))
+def test_list_tasks_node(ctr_client: DockerClient):
+    with ctr_client.service.create("busybox", ["sleep", "infinity"]) as my_service:
+        assert ctr_client.node.ps([]) == []
+        assert set(ctr_client.node.ps()) == set(ctr_client.service.ps(my_service))


### PR DESCRIPTION
From https://github.com/gabrieldemarmiesse/python-on-whales/pull/520#issuecomment-1880067542:

> I would say the more correct way to use pytest is to use fixtures for any resources (where the `DockerClient` instance is the main resource in this case), i.e. this should be done whether used for parameterisation or not. This allows performing checks, controlling initialisation and controlling cleanup - in our case we want it to be parameterised and controlled via a CLI arg.

This PR illustrates the improvement this offers - it makes it more explicit when testcases are using the `DockerClient` resource, which can be suitably set up in the fixture.

Extensive information about pytest's fixtures and how they can/should be used is available at https://docs.pytest.org/en/latest/explanation/fixtures.html.

I've currently only updated a few test modules to use the fixture, but happy to do the same for the rest of the tests. This should be considered a nice precursor to parameterising on other runtimes, but for now this would at least allow manually running with podman.

Default, using docker (no change):
```
(venv) python-on-whales/(ctr_client_fixture)$python -m pytest tests/ -k test_image_repr -vv --log-cli-level info
=============================================== test session starts ================================================
platform linux -- Python 3.9.5, pytest-7.1.2, pluggy-1.0.0 -- /mnt/c/Users/legaul/repos/python-on-whales/venv/bin/python
cachedir: .pytest_cache
rootdir: /mnt/c/Users/legaul/repos/python-on-whales
plugins: mock-3.8.2
collected 459 items / 458 deselected / 1 selected

tests/python_on_whales/components/test_image.py::test_image_repr
-------------------------------------------------- live log setup --------------------------------------------------
INFO     conftest:conftest.py:19 Running tests with container exe: docker
PASSED                                                                                                       [100%]

======================================== 1 passed, 458 deselected in 9.67s =========================================
```

Using podman:
```
(venv) python-on-whales/(ctr_client_fixture)$python -m pytest tests/ -k test_image_repr -vv --log-cli-level info --ctr-exe podman
=============================================== test session starts ================================================
platform linux -- Python 3.9.5, pytest-7.1.2, pluggy-1.0.0 -- /mnt/c/Users/legaul/repos/python-on-whales/venv/bin/python
cachedir: .pytest_cache
rootdir: /mnt/c/Users/legaul/repos/python-on-whales
plugins: mock-3.8.2
collected 459 items / 458 deselected / 1 selected

tests/python_on_whales/components/test_image.py::test_image_repr
-------------------------------------------------- live log setup --------------------------------------------------
INFO     conftest:conftest.py:19 Running tests with container exe: podman
PASSED                                                                                                       [100%]

======================================== 1 passed, 458 deselected in 10.62s ========================================
```

Using a container exe that's not available:
```
(venv) python-on-whales/(ctr_client_fixture)$python -m pytest tests/ -k test_image_repr -vv --log-cli-level info --ctr-exe nerdctl --tb short
=============================================== test session starts ================================================
platform linux -- Python 3.9.5, pytest-7.1.2, pluggy-1.0.0 -- /mnt/c/Users/legaul/repos/python-on-whales/venv/bin/python
cachedir: .pytest_cache
rootdir: /mnt/c/Users/legaul/repos/python-on-whales
plugins: mock-3.8.2
collected 459 items / 458 deselected / 1 selected

tests/python_on_whales/components/test_image.py::test_image_repr
-------------------------------------------------- live log setup --------------------------------------------------
INFO     conftest:conftest.py:19 Running tests with container exe: nerdctl
ERROR                                                                                                        [100%]

====================================================== ERRORS ======================================================
________________________________________ ERROR at setup of test_image_repr _________________________________________
tests/conftest.py:24: in ctr_client
    subprocess.run(
/usr/lib/python3.9/subprocess.py:505: in run
    with Popen(*popenargs, **kwargs) as process:
/usr/lib/python3.9/subprocess.py:951: in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
/usr/lib/python3.9/subprocess.py:1821: in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
E   FileNotFoundError: [Errno 2] No such file or directory: 'nerdctl'

The above exception was the direct cause of the following exception:
tests/conftest.py:43: in ctr_client
    raise RuntimeError(
E   RuntimeError: Unable to run with container exe 'nerdctl'.
E   'nerdctl version' command failed: executable not found
------------------------------------------------ Captured log setup ------------------------------------------------
INFO     conftest:conftest.py:19 Running tests with container exe: nerdctl
============================================= short test summary info ==============================================
ERROR tests/python_on_whales/components/test_image.py::test_image_repr - RuntimeError: Unable to run with contain...
========================================= 458 deselected, 1 error in 3.18s =========================================
```