### PR TITLE
:sparkles: Added argument `client_type` to add custom logic later

### DIFF
--- a/python_on_whales/__init__.py
+++ b/python_on_whales/__init__.py
@@ -21,7 +21,7 @@ from .docker_client import DockerClient
 from .exceptions import DockerException
 
 # alias
-docker = DockerClient()
+docker = DockerClient(client_type="docker")
 
 __all__ = [
     "Builder",

--- a/python_on_whales/client_config.py
+++ b/python_on_whales/client_config.py
@@ -5,7 +5,7 @@ import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import pydantic
 
@@ -65,6 +65,7 @@ class ClientConfig:
     compose_project_directory: Optional[ValidPath] = None
     compose_compatibility: Optional[bool] = None
     client_call: List[str] = field(default_factory=lambda: ["docker"])
+    client_type: Literal["docker", "podman", "nerdctl", "unknown"] = "unknown"
     _client_call_with_path: Optional[List[Union[Path, str]]] = None
 
     def get_client_call_with_path(self) -> List[Union[Path, str]]:

--- a/python_on_whales/docker_client.py
+++ b/python_on_whales/docker_client.py
@@ -1,6 +1,6 @@
 import base64
 import warnings
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from python_on_whales.client_config import ClientConfig, DockerCLICaller
 from python_on_whales.components.buildx.cli_wrapper import BuildxCLI
@@ -79,6 +79,13 @@ class DockerClient(DockerCLICaller):
             program execution).
         client_binary: Deprecated, use `client_call`. If you used before `client_binary="podman"`, now use
             `client_call=["podman"]`.
+        client_type: The kind of client that is called by the Python process. It allows Python-on-whales to
+            adapt to the client's behavior if two client have a different behavior. The `client_call` is not
+            enough for Python-on-whales to know what kind of client you're using. For example, if you use
+            a symlink to call Docker, Python-on-whales will not know that you're using Docker.
+            Default is "unknown". If at some point, Python-on-whales has to choose
+            a behavior and `client_type` is `"unknown"`, it will raise an exception and ask you to specify
+            what kind of client you're working with. Valid values are `"docker"`, `"podman"`, "`nerdctl"` and `"unknown"`.
     """
 
     def __init__(
@@ -102,6 +109,7 @@ class DockerClient(DockerCLICaller):
         compose_compatibility: Optional[bool] = None,
         client_binary: str = "docker",
         client_call: List[str] = ["docker"],
+        client_type: Literal["docker", "podman", "nerdctl", "unknown"] = "unknown",
     ):
         if client_binary != "docker":
             warnings.warn(
@@ -129,6 +137,7 @@ class DockerClient(DockerCLICaller):
                 compose_project_directory=compose_project_directory,
                 compose_compatibility=compose_compatibility,
                 client_call=client_call,
+                client_type=client_type,
             )
         super().__init__(client_config)
 


### PR DESCRIPTION
@LewisGaul  that should help to do the xfail for the PR https://github.com/gabrieldemarmiesse/python-on-whales/pull/523 

The idea is that it's not required to specify it by a user, but if python-on-whales needs it at some point, we just ask the user to add it to the DockerCLient constructor.

We could call "something version" instead and try to parse the output, but this option is more explicit and faster because it doesn't require a call at every program start.