### PR TITLE
Support podman in test_image.py, improve parameterisation/marking mechanism

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -93,7 +93,7 @@ jobs:
           pip install -r tests/test-requirements.txt
       - name: Run single test
         run: |
-          python -m pytest -vv tests/python_on_whales/components/test_volume.py::test_simple_volume
+          python -m pytest -vv -m "not podman" tests/python_on_whales/components/test_volume.py::test_simple_volume
 
 #  cost too much at the moment.
 #  build-macos:
@@ -118,4 +118,4 @@ jobs:
 #          pip install -r tests/test-requirements.txt
 #      - name: Run all tests
 #        run: |
-#          python -m pytest -vv tests/
+#          python -m pytest -vv -m "not podman" tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -61,7 +61,7 @@ jobs:
           pip install --upgrade ${{ matrix.pydantic-version }}
       - name: Run tests
         run: |
-          python -m pytest -vv --durations=10 tests/python_on_whales/components/${{ matrix.component }}
+          python -m pytest -vv --no-runtime-skip --durations=10 tests/python_on_whales/components/${{ matrix.component }}
 
   build-linux-test-other:
     runs-on: ubuntu-latest
@@ -75,7 +75,7 @@ jobs:
           ./scripts/ci-setup.sh
       - name: Run tests
         run: |
-          python -m pytest -vv --durations=10 --ignore=tests/python_on_whales/components/
+          python -m pytest -vv --no-runtime-skip --durations=10 --ignore=tests/python_on_whales/components/
 
   build-windows:
     runs-on: windows-latest
@@ -93,7 +93,7 @@ jobs:
           pip install -r tests/test-requirements.txt
       - name: Run single test
         run: |
-          python -m pytest -vv -m "not podman" tests/python_on_whales/components/test_volume.py::test_simple_volume
+          python -m pytest -vv --no-runtime-skip -m "not podman" tests/python_on_whales/components/test_volume.py::test_simple_volume
 
 #  cost too much at the moment.
 #  build-macos:
@@ -118,4 +118,4 @@ jobs:
 #          pip install -r tests/test-requirements.txt
 #      - name: Run all tests
 #        run: |
-#          python -m pytest -vv -m "not podman" tests/
+#          python -m pytest -vv --no-runtime-skip -m "not podman" tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,4 @@ markers = [
     "docker: marks tests as needing a docker engine to run",
     "podman: marks tests as needing a podman engine to run"
 ]
+testpaths = ["tests/"]

--- a/python_on_whales/test_utils.py
+++ b/python_on_whales/test_utils.py
@@ -29,12 +29,12 @@ def get_all_jsons(object_types: str) -> List[Path]:
     return sorted(list(jsons_directory.iterdir()), key=lambda x: int(x.stem))
 
 
-DOCKER_TEST_FLAG = "DOCKER_TEST_FLAG"
-PODMAN_TEST_FLAG = "PODMAN_TEST_FLAG"
-
-docker_client = pytest.param(
-    DOCKER_TEST_FLAG, marks=pytest.mark.docker, id="docker client"
-)
-podman_client = pytest.param(
-    PODMAN_TEST_FLAG, marks=pytest.mark.podman, id="podman client"
-)
+def parametrize_ctr_client(*args) -> pytest.MarkDecorator:
+    return pytest.mark.parametrize(
+        "ctr_client",
+        [
+            pytest.param(runtime, marks=getattr(pytest.mark, runtime))
+            for runtime in args
+        ],
+        indirect=True,
+    )

--- a/python_on_whales/test_utils.py
+++ b/python_on_whales/test_utils.py
@@ -4,8 +4,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import List
 
-import pytest
-
 from python_on_whales import client_config
 from python_on_whales.utils import PROJECT_ROOT
 
@@ -27,14 +25,3 @@ def get_all_jsons(object_types: str) -> List[Path]:
         PROJECT_ROOT / "tests/python_on_whales/components/jsons" / object_types
     )
     return sorted(list(jsons_directory.iterdir()), key=lambda x: int(x.stem))
-
-
-def parametrize_ctr_client(*args) -> pytest.MarkDecorator:
-    return pytest.mark.parametrize(
-        "ctr_client",
-        [
-            pytest.param(runtime, marks=getattr(pytest.mark, runtime))
-            for runtime in args
-        ],
-        indirect=True,
-    )

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -7,6 +7,7 @@ THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 "$THIS_DIR"/add-local-docker-registry.sh
 "$THIS_DIR"/download-docker-plugins.sh
 docker info
+podman info
 
 pip install -U pip wheel
 pip install -e ./

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -8,9 +8,8 @@ from python_on_whales import DockerClient, docker
 from python_on_whales.components.image.models import ImageInspectResult
 from python_on_whales.exceptions import DockerException, NoSuchImage
 from python_on_whales.test_utils import (
-    docker_client,
     get_all_jsons,
-    podman_client,
+    parametrize_ctr_client,
     random_name,
 )
 
@@ -22,22 +21,23 @@ def test_load_json(json_file):
     # we could do more checks here if needed
 
 
-def test_image_repr():
-    docker.image.pull("busybox:1", quiet=True)
-    docker.image.pull("busybox:1.32", quiet=True)
-    assert "busybox:1" in repr(docker.image.list())
-    assert "busybox:1.32" in repr(docker.image.list())
-    docker.image.remove(["busybox:1", "busybox:1.32"])
+@parametrize_ctr_client("docker", "podman")
+def test_image_repr(ctr_client: DockerClient):
+    ctr_client.image.pull("busybox:1", quiet=True)
+    ctr_client.image.pull("busybox:1.32", quiet=True)
+    assert "busybox:1" in repr(ctr_client.image.list())
+    assert "busybox:1.32" in repr(ctr_client.image.list())
+    ctr_client.image.remove(["busybox:1", "busybox:1.32"])
 
 
-@pytest.mark.parametrize("ctr_client", [docker_client, podman_client], indirect=True)
+@parametrize_ctr_client("docker", "podman")
 def test_image_remove(ctr_client: DockerClient):
     ctr_client.image.pull("busybox:1", quiet=True)
     ctr_client.image.pull("busybox:1.32", quiet=True)
     ctr_client.image.remove(["busybox:1", "busybox:1.32"])
 
 
-@pytest.mark.parametrize("ctr_client", [docker_client, podman_client], indirect=True)
+@parametrize_ctr_client("docker", "podman")
 def test_image_save_load(ctr_client: DockerClient, tmp_path: Path):
     if ctr_client.client_config.client_type == "podman":
         pytest.xfail("podman save/load is not implemented yet")

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -40,9 +40,9 @@ def test_image_remove(ctr_client: DockerClient):
         "docker",
         pytest.param(
             "podman",
-            marks=[
-                pytest.mark.xfail("podman.image.load() gives SHA instead of image tag")
-            ],
+            marks=pytest.mark.xfail(
+                reason="podman.image.load() gives SHA instead of image tag"
+            ),
         ),
     ],
     indirect=True,
@@ -74,9 +74,9 @@ def test_save_iterator_bytes(ctr_client: DockerClient):
         "docker",
         pytest.param(
             "podman",
-            marks=[
-                pytest.mark.xfail("podman.image.load() gives SHA instead of image tag")
-            ],
+            marks=pytest.mark.xfail(
+                reason="podman.image.load() gives SHA instead of image tag"
+            ),
         ),
     ],
     indirect=True,
@@ -97,9 +97,9 @@ def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
         "docker",
         pytest.param(
             "podman",
-            marks=[
-                pytest.mark.xfail("podman.image.load() gives SHA instead of image tag")
-            ],
+            marks=pytest.mark.xfail(
+                reason="podman.image.load() gives SHA instead of image tag"
+            ),
         ),
     ],
     indirect=True,
@@ -112,10 +112,21 @@ def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
     ctr_client.image.inspect("busybox:1")
 
 
-@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
+@pytest.mark.parametrize(
+    "ctr_client",
+    [
+        "docker",
+        pytest.param(
+            "podman",
+            marks=pytest.mark.xfail(
+                reason="podman.image.load() gives SHA instead of image tag"
+            ),
+        ),
+    ],
+    indirect=True,
+)
 def test_save_iterator_bytes_and_load_from_iterator_list_of_images(
     ctr_client: DockerClient,
-    xfail={"podman": "podman.image.load() gives SHA instead of image tag"},
 ):
     images = ctr_client.image.pull(["busybox:1", "hello-world:latest"], quiet=True)
     image_tags = {tag for image in images for tag in image.repo_tags}
@@ -183,7 +194,7 @@ def test_pull_not_quiet(ctr_client: DockerClient):
 
 @pytest.mark.parametrize(
     "ctr_client",
-    ["docker", pytest.param("podman", marks=[pytest.mark.xfail])],
+    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
     indirect=True,
 )
 def test_pull_not_quiet_multiple_images(ctr_client: DockerClient):
@@ -252,7 +263,7 @@ def test_remove_nothing(ctr_client: DockerClient):
 
 @pytest.mark.parametrize(
     "ctr_client",
-    ["docker", pytest.param("podman", marks=[pytest.mark.xfail])],
+    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
     indirect=True,
 )
 def test_no_such_image_inspect(ctr_client: DockerClient):
@@ -265,7 +276,7 @@ def test_no_such_image_inspect(ctr_client: DockerClient):
 
 @pytest.mark.parametrize(
     "ctr_client",
-    ["docker", pytest.param("podman", marks=[pytest.mark.xfail])],
+    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
     indirect=True,
 )
 def test_no_such_image_remove(ctr_client: DockerClient):
@@ -278,7 +289,7 @@ def test_no_such_image_remove(ctr_client: DockerClient):
 
 @pytest.mark.parametrize(
     "ctr_client",
-    ["docker", pytest.param("podman", marks=[pytest.mark.xfail])],
+    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
     indirect=True,
 )
 def test_no_such_image_push(ctr_client: DockerClient):
@@ -291,7 +302,7 @@ def test_no_such_image_push(ctr_client: DockerClient):
 
 @pytest.mark.parametrize(
     "ctr_client",
-    ["docker", pytest.param("podman", marks=[pytest.mark.xfail])],
+    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
     indirect=True,
 )
 def test_no_such_image_save(ctr_client: DockerClient):
@@ -304,7 +315,7 @@ def test_no_such_image_save(ctr_client: DockerClient):
 
 @pytest.mark.parametrize(
     "ctr_client",
-    ["docker", pytest.param("podman", marks=[pytest.mark.xfail])],
+    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
     indirect=True,
 )
 def test_no_such_image_save_generator(ctr_client: DockerClient):
@@ -318,7 +329,7 @@ def test_no_such_image_save_generator(ctr_client: DockerClient):
 
 @pytest.mark.parametrize(
     "ctr_client",
-    ["docker", pytest.param("podman", marks=[pytest.mark.xfail])],
+    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
     indirect=True,
 )
 def test_no_such_image_tag(ctr_client: DockerClient):
@@ -331,7 +342,7 @@ def test_no_such_image_tag(ctr_client: DockerClient):
 
 @pytest.mark.parametrize(
     "ctr_client",
-    ["docker", pytest.param("podman", marks=[pytest.mark.xfail])],
+    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
     indirect=True,
 )
 def test_exists(ctr_client: DockerClient):

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -51,7 +51,7 @@ def test_save_load(ctr_client: DockerClient, tmp_path: Path):
     tar_file = tmp_path / "dodo.tar"
     image = ctr_client.image.pull("busybox:1", quiet=True)
     image_tags = image.repo_tags
-    image.save(output=tar_file)
+    ctr_client.image.save("busybox:1", output=tar_file)
     image.remove(force=True)
     assert ctr_client.image.load(input=tar_file) == image_tags
 
@@ -84,7 +84,7 @@ def test_save_iterator_bytes(ctr_client: DockerClient):
 def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
     image = ctr_client.image.pull("busybox:1", quiet=True)
     image_tags = image.repo_tags
-    iterator = image.save()
+    iterator = ctr_client.image.save("busybox:1")
     my_tar_as_bytes = b"".join(iterator)
     image.remove(force=True)
     assert ctr_client.image.load(my_tar_as_bytes) == image_tags
@@ -107,7 +107,7 @@ def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
 def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
     image = ctr_client.image.pull("busybox:1", quiet=True)
     image_tags = image.repo_tags
-    iterator = image.save()
+    iterator = ctr_client.image.save("busybox:1")
     assert ctr_client.image.load(iterator) == image_tags
     ctr_client.image.inspect("busybox:1")
 
@@ -128,11 +128,12 @@ def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
 def test_save_iterator_bytes_and_load_from_iterator_list_of_images(
     ctr_client: DockerClient,
 ):
-    images = ctr_client.image.pull(["busybox:1", "hello-world:latest"], quiet=True)
+    image_names = ["busybox:1", "hello-world:latest"]
+    images = ctr_client.image.pull(image_names, quiet=True)
     image_tags = {tag for image in images for tag in image.repo_tags}
-    iterator = ctr_client.image.save(images)
+    iterator = ctr_client.image.save(image_names)
     assert set(ctr_client.image.load(iterator)) == image_tags
-    ctr_client.image.inspect(["busybox:1", "hello-world:latest"])
+    ctr_client.image.inspect(image_names)
 
 
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -136,7 +136,19 @@ def test_save_iterator_bytes_and_load_from_iterator_list_of_images(
     ctr_client.image.inspect(image_names)
 
 
-@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
+@pytest.mark.parametrize(
+    "ctr_client",
+    [
+        "docker",
+        pytest.param(
+            "podman",
+            marks=pytest.mark.xfail(
+                reason="podman lists images with registry in image name"
+            ),
+        ),
+    ],
+    indirect=True,
+)
 def test_filter_when_listing(ctr_client: DockerClient):
     ctr_client.pull(["hello-world", "busybox"])
     images_listed = ctr_client.image.list(filters=dict(reference="hello-world"))
@@ -160,7 +172,19 @@ def test_filter_when_listing_old_signature(docker_client: DockerClient):
     assert tags == {"hello-world:latest"}
 
 
-@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
+@pytest.mark.parametrize(
+    "ctr_client",
+    [
+        "docker",
+        pytest.param(
+            "podman",
+            marks=pytest.mark.xfail(
+                reason="podman lists images with registry in image name"
+            ),
+        ),
+    ],
+    indirect=True,
+)
 def test_use_first_argument_to_filter(ctr_client: DockerClient):
     ctr_client.pull(["hello-world", "busybox"])
     images_listed = ctr_client.image.list("hello-world")


### PR DESCRIPTION
- Support podman in CI:
  - Add `podman info` output
  - Do not skip tests in CI if docker/podman are not working using new `--no-runtime-skip` CLI arg
  - Deselect podman tests in CI on Windows
- Improve `ctr_client` parameterisation:
  - Automatically apply docker/podman marks (in `pytest_collection_modifyitems()` hook)
  - Remove indirection when parameterising `ctr_client` (no need to import anything from `test_utils`)
  - Simplify code that gets and checks container client (no need for `TestSessionClient` class)
  - Support using `docker_client` and `podman_client` fixtures directly for testcases that do not need parameterising
- Fully parameterise `test_image.py` with podman
  - Some tests updated to support minor differences in podman
  - Other tests marked as xfail for podman for now (note `--runxfail` is useful for bulk fixing xfail tests)
  - Some tests don't make sense to parameterise

More test parameterisation to come (in separate PR)...