### PR TITLE
Podman upgrade in CI, use xfail_strict and remove xfails that now pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,4 @@ markers = [
     "docker: marks tests as needing a docker engine to run",
     "podman: marks tests as needing a podman engine to run"
 ]
+xfail_strict = true

--- a/scripts/ci-podman-update.sh
+++ b/scripts/ci-podman-update.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ubuntu_version='22.04'
+key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
+sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
+
+echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
+curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+sudo apt update -y
+sudo apt install -y podman

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -6,6 +6,8 @@ THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 "$THIS_DIR"/add-local-docker-registry.sh
 "$THIS_DIR"/download-docker-plugins.sh
+"$THIS_DIR"/ci-podman-update.sh
+
 docker info
 podman info
 

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -140,11 +140,7 @@ sys.exit(1)
         assert "Something is wrong!" in str(err.value)
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_container_repr(ctr_client: DockerClient):
     with ctr_client.run(
         "ubuntu",
@@ -156,11 +152,7 @@ def test_container_repr(ctr_client: DockerClient):
         assert container.id[:12] in repr(ctr_client.container.list())
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_run_with_random_port(ctr_client: DockerClient):
     with ctr_client.run(
         "ubuntu",
@@ -325,11 +317,7 @@ def test_simple_logs_follow(ctr_client: DockerClient):
         assert output == "dodo\n"
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_simple_logs_stream(ctr_client: DockerClient):
     with ctr_client.run("busybox:1", ["echo", "dodo"], detach=True) as c:
         time.sleep(0.3)
@@ -337,11 +325,7 @@ def test_simple_logs_stream(ctr_client: DockerClient):
         assert output == [("stdout", b"dodo\n")]
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_simple_logs_stream_stderr(ctr_client: DockerClient):
     with ctr_client.run("busybox:1", ["sh", "-c", ">&2 echo dodo"], detach=True) as c:
         time.sleep(0.3)
@@ -349,11 +333,7 @@ def test_simple_logs_stream_stderr(ctr_client: DockerClient):
         assert output == [("stderr", b"dodo\n")]
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_simple_logs_stream_stdout_and_stderr(ctr_client: DockerClient):
     with ctr_client.run(
         "busybox:1", ["sh", "-c", ">&2 echo dodo && echo dudu"], detach=True
@@ -365,11 +345,7 @@ def test_simple_logs_stream_stdout_and_stderr(ctr_client: DockerClient):
         assert set(output) == {("stderr", b"dodo\n"), ("stdout", b"dudu\n")}
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_simple_logs_stream_wait(ctr_client: DockerClient):
     with ctr_client.run(
         "busybox:1", ["sh", "-c", "sleep 3 && echo dodo"], detach=True
@@ -429,11 +405,7 @@ def test_container_state(ctr_client: DockerClient):
     )
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_restart(ctr_client: DockerClient):
     cmd = ["sleep", "infinity"]
     containers = [ctr_client.run("busybox:1", cmd, detach=True) for _ in range(3)]
@@ -511,6 +483,7 @@ def test_kill_signal(ctr_client: DockerClient):
         "busybox:1", ["sleep", "infinity"], init=True, detach=True
     )
     my_container.kill(signal=signal.SIGINT)
+    my_container.reload()
     assert not my_container.state.running
     assert my_container.state.exit_code == 130
     my_container.remove()
@@ -870,11 +843,7 @@ def test_rename_nosuchcontainer(ctr_client: DockerClient):
         ctr_client.container.rename("dodueizbgueirzhgueoz", "new_name")
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_update_nosuchcontainer(ctr_client: DockerClient):
     with pytest.raises(NoSuchContainer):
         ctr_client.container.update("grueighuri", cpus=1)

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -34,19 +34,7 @@ def test_image_remove(ctr_client: DockerClient):
     ctr_client.image.remove(["busybox:1", "busybox:1.32"])
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    [
-        "docker",
-        pytest.param(
-            "podman",
-            marks=pytest.mark.xfail(
-                reason="podman.image.load() gives SHA instead of image tag"
-            ),
-        ),
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_save_load(ctr_client: DockerClient, tmp_path: Path):
     tar_file = tmp_path / "dodo.tar"
     image = ctr_client.image.pull("busybox:1", quiet=True)
@@ -68,19 +56,7 @@ def test_save_iterator_bytes(ctr_client: DockerClient):
     assert i != 0
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    [
-        "docker",
-        pytest.param(
-            "podman",
-            marks=pytest.mark.xfail(
-                reason="podman.image.load() gives SHA instead of image tag"
-            ),
-        ),
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
     image = ctr_client.image.pull("busybox:1", quiet=True)
     image_tags = image.repo_tags
@@ -91,19 +67,7 @@ def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
     ctr_client.image.inspect("busybox:1")
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    [
-        "docker",
-        pytest.param(
-            "podman",
-            marks=pytest.mark.xfail(
-                reason="podman.image.load() gives SHA instead of image tag"
-            ),
-        ),
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
     image = ctr_client.image.pull("busybox:1", quiet=True)
     image_tags = image.repo_tags
@@ -114,15 +78,7 @@ def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
 
 @pytest.mark.parametrize(
     "ctr_client",
-    [
-        "docker",
-        pytest.param(
-            "podman",
-            marks=pytest.mark.xfail(
-                reason="podman.image.load() gives SHA instead of image tag"
-            ),
-        ),
-    ],
+    ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
     indirect=True,
 )
 def test_save_iterator_bytes_and_load_from_iterator_list_of_images(


### PR DESCRIPTION
Also checked this unblocks https://github.com/gabrieldemarmiesse/python-on-whales/pull/533. This doesn't actually pin the podman version (it gives us v4.6, which is pretty recent), but I'm not sure how we would do that.