### PR TITLE
Tidy up `ReloadableObjectFromJson._fetch_inspect_result_json()`

### DIFF
--- a/python_on_whales/client_config.py
+++ b/python_on_whales/client_config.py
@@ -239,14 +239,13 @@ class ReloadableObjectFromJson(ReloadableObject):
         raise NotImplementedError
 
     def _fetch_and_parse_inspect_result(self, reference: str):
-        json_str = self._fetch_inspect_result_json(reference)
-        json_object = json.loads(json_str)[0]
+        json_object = self._fetch_inspect_result_json(reference)
         try:
             return self._parse_json_object(json_object)
         except pydantic.ValidationError as err:
             fd, json_response_file = tempfile.mkstemp(suffix=".json", text=True)
             with open(json_response_file, "w") as f:
-                f.write(json_str)
+                json.dump(json_object, f, indent=2)
 
             raise ParsingError(
                 f"There was an error parsing the json response from the Docker daemon. \n"

--- a/python_on_whales/components/config/cli_wrapper.py
+++ b/python_on_whales/components/config/cli_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, overload
@@ -30,7 +31,8 @@ class Config(ReloadableObjectFromJson):
         self.remove()
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["config", "inspect", reference])
+        json_str = run(self.docker_cmd + ["config", "inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]):
         return ConfigInspectResult(**json_object)

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -91,7 +91,8 @@ class Container(ReloadableObjectFromJson):
             self.remove(volumes=True)
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["container", "inspect", reference])
+        json_str = run(self.docker_cmd + ["container", "inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]):
         return ContainerInspectResult(**json_object)

--- a/python_on_whales/components/context/cli_wrapper.py
+++ b/python_on_whales/components/context/cli_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, overload
@@ -36,7 +37,8 @@ class Context(ReloadableObjectFromJson):
         full_cmd = self.docker_cmd + ["context", "inspect"]
         if reference is not None:
             full_cmd.append(reference)
-        return run(full_cmd)
+        json_str = run(full_cmd)
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]):
         return ContextInspectResult(**json_object)

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import warnings
 from datetime import datetime
 from multiprocessing.pool import ThreadPool
@@ -45,7 +46,8 @@ class Image(ReloadableObjectFromJson):
         self.remove(force=True)
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["image", "inspect", reference])
+        json_str = run(self.docker_cmd + ["image", "inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]) -> ImageInspectResult:
         return ImageInspectResult(**json_object)

--- a/python_on_whales/components/manifest/cli_wrapper.py
+++ b/python_on_whales/components/manifest/cli_wrapper.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, List, Optional, Union
 
 from python_on_whales.client_config import (
@@ -24,7 +25,8 @@ class ManifestList(ReloadableObjectFromJson):
         self.remove()
 
     def _fetch_inspect_result_json(self, reference):
-        return f'[{run(self.docker_cmd + ["manifest", "inspect", reference])}]'
+        json_str = run(self.docker_cmd + ["manifest", "inspect", reference])
+        return json.loads(json_str)
 
     def _parse_json_object(
         self, json_object: Dict[str, Any]

--- a/python_on_whales/components/network/cli_wrapper.py
+++ b/python_on_whales/components/network/cli_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union, overload
 
@@ -30,7 +31,8 @@ class Network(ReloadableObjectFromJson):
         self.remove()
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["network", "inspect", reference])
+        json_str = run(self.docker_cmd + ["network", "inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]) -> NetworkInspectResult:
         return NetworkInspectResult(**json_object)

--- a/python_on_whales/components/node/cli_wrapper.py
+++ b/python_on_whales/components/node/cli_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union, overload
 
@@ -27,7 +28,8 @@ class Node(ReloadableObjectFromJson):
         super().__init__(client_config, "id", reference, is_immutable_id)
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["node", "inspect", reference])
+        json_str = run(self.docker_cmd + ["node", "inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]) -> NodeInspectResult:
         return NodeInspectResult(**json_object)

--- a/python_on_whales/components/plugin/cli_wrapper.py
+++ b/python_on_whales/components/plugin/cli_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List, Optional, Union, overload
 
 from python_on_whales.client_config import (
@@ -28,7 +29,8 @@ class Plugin(ReloadableObjectFromJson):
         self.remove(force=True)
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["plugin", "inspect", reference])
+        json_str = run(self.docker_cmd + ["plugin", "inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]) -> PluginInspectResult:
         return PluginInspectResult(**json_object)

--- a/python_on_whales/components/secret/cli_wrapper.py
+++ b/python_on_whales/components/secret/cli_wrapper.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, List, Optional, Union
 
 from python_on_whales.client_config import (
@@ -22,7 +23,8 @@ class Secret(ReloadableObjectFromJson):
         self.remove()
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["secret", "inspect", reference])
+        json_str = run(self.docker_cmd + ["secret", "inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]) -> SecretInspectResult:
         return SecretInspectResult(**json_object)

--- a/python_on_whales/components/service/cli_wrapper.py
+++ b/python_on_whales/components/service/cli_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Literal, Optional, Union, overload
 
@@ -41,7 +42,8 @@ class Service(ReloadableObjectFromJson):
         self.remove()
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["service", "inspect", reference])
+        json_str = run(self.docker_cmd + ["service", "inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]) -> ServiceInspectResult:
         return ServiceInspectResult(**json_object)

--- a/python_on_whales/components/task/cli_wrapper.py
+++ b/python_on_whales/components/task/cli_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
@@ -26,7 +27,8 @@ class Task(ReloadableObjectFromJson):
         super().__init__(client_config, "id", reference, is_immutable_id)
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["inspect", reference])
+        json_str = run(self.docker_cmd + ["inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]) -> TaskInspectResult:
         return TaskInspectResult(**json_object)

--- a/python_on_whales/components/volume/cli_wrapper.py
+++ b/python_on_whales/components/volume/cli_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 from datetime import datetime
@@ -33,7 +34,8 @@ class Volume(ReloadableObjectFromJson):
         self.remove()
 
     def _fetch_inspect_result_json(self, reference):
-        return run(self.docker_cmd + ["volume", "inspect", reference])
+        json_str = run(self.docker_cmd + ["volume", "inspect", reference])
+        return json.loads(json_str)[0]
 
     def _parse_json_object(self, json_object: Dict[str, Any]):
         return VolumeInspectResult(**json_object)

--- a/tests/python_on_whales/test_client_config.py
+++ b/tests/python_on_whales/test_client_config.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -5,21 +6,15 @@ import pytest
 from python_on_whales import docker
 from python_on_whales.client_config import ParsingError
 
-fake_json_message = """
-[
-    {
-        "CreatedAt": "2020-10-08T18:32:55Z",
-        "Driver": ["dummy", "fake", ["driver"]],
-        "Labels": {
-            "com.docker.stack.namespace": "dodo"
-        },
-        "Mountpoint": "/var/lib/docker/volumes/dodo_traefik-data/_data",
-        "Name": "dodo_traefik-data",
-        "Options": null,
-        "Scope": "local"
-    }
-]
-"""
+fake_json_message = {
+    "CreatedAt": "2020-10-08T18:32:55Z",
+    "Driver": ["dummy", "fake", ["driver"]],
+    "Labels": {"com.docker.stack.namespace": "dodo"},
+    "Mountpoint": "/var/lib/docker/volumes/dodo_traefik-data/_data",
+    "Name": "dodo_traefik-data",
+    "Options": None,
+    "Scope": "local",
+}
 
 
 def test_pretty_exception_message_and_report(mocker):
@@ -40,4 +35,4 @@ def test_pretty_exception_message_and_report(mocker):
     else:
         raise IndexError
 
-    assert Path(word).read_text() == fake_json_message
+    assert Path(word).read_text() == json.dumps(fake_json_message, indent=2)


### PR DESCRIPTION
The `ReloadableObjectFromJson._fetch_inspect_result_json()` method implemented for each component is now expected to return an object loaded from JSON, rather than expecting the result from `<ctr_exe> <subcmd> inspect` to always be a list.

This allows removing the hack in `python_on_whales/components/manifest/cli_wrapper.py` (and avoids having to do similar for `podman pod inspect`), which looked like:
```python
    def _fetch_inspect_result_json(self, reference):
        return f'[{run(self.docker_cmd + ["manifest", "inspect", reference])}]'
```