### PR TITLE
Various tidyup for container `cli_wrapper.py`

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -469,7 +469,7 @@ class ContainerCLI(DockerCLICaller):
         # TODO: fixme
         # full_cmd += ["--pause", str(pause).lower()]
 
-        full_cmd.append(container)
+        full_cmd.append(str(container))
         if tag is not None:
             full_cmd.append(tag)
 
@@ -791,8 +791,8 @@ class ContainerCLI(DockerCLICaller):
 
         full_cmd.add_simple_arg("--workdir", workdir)
 
-        full_cmd.append(str(image))
-        full_cmd.extend(command)
+        full_cmd.append(image)
+        full_cmd += command
         return Container(self.client_config, run(full_cmd), is_immutable_id=True)
 
     def diff(self, container: ValidContainer) -> Dict[str, str]:
@@ -1020,7 +1020,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd = self.docker_cmd + ["container", "kill"]
 
         full_cmd.add_simple_arg("--signal", format_signal_arg(signal))
-        full_cmd.extend(containers)
+        full_cmd += containers
 
         run(full_cmd)
 
@@ -1792,7 +1792,7 @@ class ContainerCLI(DockerCLICaller):
             containers do not exist.
         """
         containers = to_list(containers)
-        if len(containers) == 0:
+        if containers == []:
             # nothing to do
             return
         full_cmd = self.docker_cmd + ["container", "stop"]

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -440,7 +440,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_simple_arg("--detach-keys", detach_keys)
         full_cmd.add_flag("--no-stdin", not stdin)
         full_cmd.add_flag("--sig-proxy", sig_proxy)
-        full_cmd.append(str(container))
+        full_cmd.append(container)
 
         run(full_cmd, tty=True)
 
@@ -469,7 +469,7 @@ class ContainerCLI(DockerCLICaller):
         # TODO: fixme
         # full_cmd += ["--pause", str(pause).lower()]
 
-        full_cmd.append(str(container))
+        full_cmd.append(container)
         if tag is not None:
             full_cmd.append(tag)
 
@@ -561,21 +561,21 @@ class ContainerCLI(DockerCLICaller):
         envs: Dict[str, str] = {},
         env_files: Union[ValidPath, List[ValidPath]] = [],
         expose: Union[int, List[int]] = [],
-        gpus: Optional[Union[int, str]] = None,
+        gpus: Union[int, str, None] = None,
         groups_add: List[str] = [],
         healthcheck: bool = True,
         health_cmd: Optional[str] = None,
-        health_interval: Optional[Union[int, timedelta]] = None,
+        health_interval: Union[None, int, timedelta] = None,
         health_retries: Optional[int] = None,
-        health_start_period: Optional[Union[int, timedelta]] = None,
-        health_timeout: Optional[Union[int, timedelta]] = None,
+        health_start_period: Union[None, int, timedelta] = None,
+        health_timeout: Union[None, int, timedelta] = None,
         hostname: Optional[str] = None,
         init: bool = False,
         ip: Optional[str] = None,
         ip6: Optional[str] = None,
         ipc: Optional[str] = None,
         isolation: Optional[str] = None,
-        kernel_memory: Optional[Union[int, str]] = None,
+        kernel_memory: Union[int, str, None] = None,
         labels: Dict[str, str] = {},
         label_files: List[ValidPath] = [],
         link: List[ValidContainer] = [],
@@ -583,9 +583,9 @@ class ContainerCLI(DockerCLICaller):
         log_driver: Optional[str] = None,
         log_options: List[str] = [],
         mac_address: Optional[str] = None,
-        memory: Optional[Union[int, str]] = None,
-        memory_reservation: Optional[Union[int, str]] = None,
-        memory_swap: Optional[Union[int, str]] = None,
+        memory: Union[int, str, None] = None,
+        memory_reservation: Union[int, str, None] = None,
+        memory_swap: Union[int, str, None] = None,
         memory_swappiness: Optional[int] = None,
         mounts: List[List[str]] = [],
         name: Optional[str] = None,
@@ -607,7 +607,7 @@ class ContainerCLI(DockerCLICaller):
         remove: bool = False,
         runtime: Optional[str] = None,
         security_options: List[str] = [],
-        shm_size: Optional[Union[int, str]] = None,
+        shm_size: Union[int, str, None] = None,
         sig_proxy: bool = True,
         stop_signal: Optional[Union[int, str]] = None,
         stop_timeout: Optional[int] = None,
@@ -1020,7 +1020,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd = self.docker_cmd + ["container", "kill"]
 
         full_cmd.add_simple_arg("--signal", format_signal_arg(signal))
-        full_cmd.extend(str(c) for c in containers)
+        full_cmd.extend(containers)
 
         run(full_cmd)
 
@@ -1088,7 +1088,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_flag("--timestamps", timestamps)
         full_cmd.add_simple_arg("--until", format_time_arg(until))
         full_cmd.add_flag("--follow", follow)
-        full_cmd.append(str(container))
+        full_cmd.append(container)
 
         iterator = stream_stdout_and_stderr(full_cmd)
 
@@ -1138,7 +1138,7 @@ class ContainerCLI(DockerCLICaller):
             # nothing to do
             return
         full_cmd = self.docker_cmd + ["pause"]
-        full_cmd.extend(str(c) for c in containers)
+        full_cmd.extend(containers)
 
         run(full_cmd)
 
@@ -1201,8 +1201,7 @@ class ContainerCLI(DockerCLICaller):
                 time = time.total_seconds()
             full_cmd += ["--time", str(time)]
 
-        for container in containers:
-            full_cmd.append(str(container))
+        full_cmd.extend(containers)
 
         run(full_cmd)
 
@@ -1233,7 +1232,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_flag("--force", force)
         full_cmd.add_flag("--volumes", volumes)
 
-        full_cmd.extend(str(c) for c in containers)
+        full_cmd.extend(containers)
 
         run(full_cmd)
 
@@ -1274,14 +1273,14 @@ class ContainerCLI(DockerCLICaller):
         envs: Dict[str, str] = {},
         env_files: Union[ValidPath, List[ValidPath]] = [],
         expose: Union[int, List[int]] = [],
-        gpus: Optional[Union[int, str]] = None,
+        gpus: Union[int, str, None] = None,
         groups_add: List[str] = [],
         healthcheck: bool = True,
         health_cmd: Optional[str] = None,
-        health_interval: Optional[Union[int, timedelta]] = None,
+        health_interval: Union[None, int, timedelta] = None,
         health_retries: Optional[int] = None,
-        health_start_period: Optional[Union[int, timedelta]] = None,
-        health_timeout: Optional[Union[int, timedelta]] = None,
+        health_start_period: Union[None, int, timedelta] = None,
+        health_timeout: Union[None, int, timedelta] = None,
         hostname: Optional[str] = None,
         init: bool = False,
         interactive: bool = False,
@@ -1289,7 +1288,7 @@ class ContainerCLI(DockerCLICaller):
         ip6: Optional[str] = None,
         ipc: Optional[str] = None,
         isolation: Optional[str] = None,
-        kernel_memory: Optional[Union[int, str]] = None,
+        kernel_memory: Union[int, str, None] = None,
         labels: Dict[str, str] = {},
         label_files: List[ValidPath] = [],
         link: List[ValidContainer] = [],
@@ -1297,9 +1296,9 @@ class ContainerCLI(DockerCLICaller):
         log_driver: Optional[str] = None,
         log_options: List[str] = [],
         mac_address: Optional[str] = None,
-        memory: Optional[Union[int, str]] = None,
-        memory_reservation: Optional[Union[int, str]] = None,
-        memory_swap: Optional[Union[int, str]] = None,
+        memory: Union[int, str, None] = None,
+        memory_reservation: Union[int, str, None] = None,
+        memory_swap: Union[int, str, None] = None,
         memory_swappiness: Optional[int] = None,
         mounts: List[List[str]] = [],
         name: Optional[str] = None,
@@ -1321,7 +1320,7 @@ class ContainerCLI(DockerCLICaller):
         remove: bool = False,
         runtime: Optional[str] = None,
         security_options: List[str] = [],
-        shm_size: Optional[Union[int, str]] = None,
+        shm_size: Union[int, str, None] = None,
         sig_proxy: bool = True,
         stop_signal: Optional[Union[int, str]] = None,
         stop_timeout: Optional[int] = None,
@@ -1767,7 +1766,7 @@ class ContainerCLI(DockerCLICaller):
         ]
         full_cmd.add_flag("--all", all)
         if containers:
-            full_cmd.extend(str(c) for c in to_list(containers))
+            full_cmd.extend(to_list(containers))
 
         stats_output = run(full_cmd)
         return [ContainerStats(json.loads(x)) for x in stats_output.splitlines()]
@@ -1798,7 +1797,7 @@ class ContainerCLI(DockerCLICaller):
             return
         full_cmd = self.docker_cmd + ["container", "stop"]
         full_cmd.add_simple_arg("--time", format_time_arg(time))
-        full_cmd.extend(str(c) for c in containers)
+        full_cmd.extend(containers)
 
         run(full_cmd)
 
@@ -1827,7 +1826,7 @@ class ContainerCLI(DockerCLICaller):
             # nothing to do
             return
         full_cmd = self.docker_cmd + ["container", "unpause"]
-        full_cmd.extend(str(c) for c in containers)
+        full_cmd.extend(containers)
         run(full_cmd)
 
     def update(

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -217,6 +217,10 @@ def post_process_stream(stream: Optional[bytes]):
 
 
 ValidPath = Union[str, Path]
+ValidPortMapping = Union[
+    Tuple[Union[str, int], Union[str, int]],
+    Tuple[Union[str, int], Union[str, int], str],
+]
 
 
 def to_list(x) -> list:
@@ -343,8 +347,36 @@ def format_signal_for_docker(signal_object: Union[int, str]) -> str:
         raise TypeError(f"Got unexpected signal type {type(signal_object).__name__!r}")
 
 
+def format_port_arg(port_object: ValidPortMapping) -> str:
+    if len(port_object) == 1:
+        return port_object[0]
+    elif len(port_object) == 2:
+        return f"{port_object[0]}:{port_object[1]}"
+    elif len(port_object) == 3:
+        return f"{port_object[0]}:{port_object[1]}/{port_object[2]}"
+    else:
+        raise ValueError(
+            "The size of the tuples in the publish list must be 1, 2, or 3"
+        )
+
+
 def parse_ls_status_count(status_output, status) -> int:
     try:
         return int(status_output.split(status + "(")[1].split(")")[0])
     except IndexError:
         return 0
+
+
+def join_if_not_none(sequence: Optional[list]) -> Optional[str]:
+    if sequence is None:
+        return None
+    sequence = [str(x) for x in sequence]
+    return ",".join(sequence)
+
+
+def to_seconds(duration: Optional[Union[int, timedelta]]) -> Optional[str]:
+    if duration is None:
+        return None
+    if isinstance(duration, timedelta):
+        duration = int(duration.total_seconds())
+    return f"{duration}s"


### PR DESCRIPTION
- Correct some type annotations
- Move some formatting helpers to `utils.py` (to be used by the `pod` component too)
- More consistency in constructing commands, e.g. using helpers such as `full_cmd.add_simple_arg()`
- Move `exists()` method to expected place in the classes
