### PR TITLE
Fix `client.container.start(attach=True)`

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1772,9 +1772,10 @@ class ContainerCLI(DockerCLICaller):
         if stream:
             return stream_stdout_and_stderr(full_cmd)
         elif attach:
-            return run(full_cmd)
+            run(full_cmd, tty=True)
+            return None
         else:
-            run(full_cmd)
+            return run(full_cmd)
 
     def stats(
         self,

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1747,7 +1747,10 @@ class ContainerCLI(DockerCLICaller):
 
         Parameters:
             containers: One or a list of containers.
-            attach: Attach stdout/stderr and forward signals.
+            attach: Attach stdout/stderr and forward signals. Note that in
+                previous versions the behaviour was to run without attaching
+                the TTY - the behaviour now matches the
+                `docker.container.attach` method.
             interactive: Attach stdin (ensure it is open).
             stream: Stream output as a generator.
             detach_keys: Override the key sequence for detaching a container.

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -323,7 +323,7 @@ def format_time_arg(time_object):
 
 def format_time_for_docker(time_object: Union[datetime, timedelta]) -> str:
     if isinstance(time_object, datetime):
-        return time_object.strftime("%Y-%m-%dT%H:%M:%S")
+        return time_object.isoformat()
     elif isinstance(time_object, timedelta):
         return f"{time_object.total_seconds()}s"
 

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -58,8 +58,8 @@ def test_simple_mistake_on_run(ctr_client: DockerClient):
 
 
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
-def test_simple_command_create_start(ctr_client: DockerClient):
-    output = ctr_client.container.create("hello-world", remove=True).start(attach=True)
+def test_simple_command_run(ctr_client: DockerClient):
+    output = ctr_client.container.run("hello-world", remove=True)
     assert "Hello from Docker!" in output
 
 


### PR DESCRIPTION
Currently output is captured by PoW when starting a container attached, which is inconsistent behaviour compared to `client.container.attach()`.