### PR TITLE
Add `detach_keys` argument for `start` and `exec`

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -389,7 +389,11 @@ class Container(ReloadableObjectFromJson):
         )
 
     def start(
-        self, attach: bool = False, detach_keys: Optional[str] = None, interactive: bool = False, stream: bool = False
+        self,
+        attach: bool = False,
+        detach_keys: Optional[str] = None,
+        interactive: bool = False,
+        stream: bool = False
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
         """Starts this container.
 

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -846,7 +846,7 @@ class ContainerCLI(DockerCLICaller):
             command: The command to execute.
             detach: if `True`, returns immediately with `None`. If `False`,
                 returns the command stdout as string.
-            detach_keys: Key sequence to detach from the container.
+            detach_keys: Override the key sequence for detaching a container.
             envs: Set environment variables
             env_files: Read one or more files of environment variables
             interactive: Leave stdin open during the duration of the process
@@ -1710,7 +1710,7 @@ class ContainerCLI(DockerCLICaller):
         Parameters:
             containers: One or a list of containers.
             attach: Attach stdout/stderr and forward signals.
-            detach_keys: Key sequence for detaching from the container.
+            detach_keys: Override the key sequence for detaching a container.
             interactive: Attach stdin (ensure it is open).
             stream: Stream output as a generator.
         """

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -268,6 +268,7 @@ class Container(ReloadableObjectFromJson):
         self,
         command: List[str],
         detach: bool = False,
+        detach_keys: Optional[str] = None,
         envs: Dict[str, str] = {},
         env_files: Union[ValidPath, List[ValidPath]] = [],
         interactive: bool = False,
@@ -286,6 +287,7 @@ class Container(ReloadableObjectFromJson):
             self,
             command,
             detach,
+            detach_keys,
             envs,
             env_files,
             interactive,
@@ -387,14 +389,14 @@ class Container(ReloadableObjectFromJson):
         )
 
     def start(
-        self, attach: bool = False, interactive: bool = False, stream: bool = False
+        self, attach: bool = False, detach_keys: Optional[str] = None, interactive: bool = False, stream: bool = False
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
         """Starts this container.
 
         See the [`docker.container.start`](../sub-commands/container.md#start) command for
         information about the arguments.
         """
-        return ContainerCLI(self.client_config).start(self, attach, interactive, stream)
+        return ContainerCLI(self.client_config).start(self, attach, detach_keys, interactive, stream)
 
     def stop(self, time: Union[int, timedelta] = None) -> None:
         """Stops this container.
@@ -825,6 +827,7 @@ class ContainerCLI(DockerCLICaller):
         container: ValidContainer,
         command: List[str],
         detach: bool = False,
+        detach_keys: Optional[str] = None,
         envs: Dict[str, str] = {},
         env_files: Union[ValidPath, List[ValidPath]] = [],
         interactive: bool = False,
@@ -843,6 +846,7 @@ class ContainerCLI(DockerCLICaller):
             command: The command to execute.
             detach: if `True`, returns immediately with `None`. If `False`,
                 returns the command stdout as string.
+            detach_keys: Key sequence to detach from the container.
             envs: Set environment variables
             env_files: Read one or more files of environment variables
             interactive: Leave stdin open during the duration of the process
@@ -882,6 +886,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd = self.docker_cmd + ["exec"]
 
         full_cmd.add_flag("--detach", detach)
+        full_cmd.add_simple_arg("--detach-keys", detach_keys)
 
         full_cmd.add_args_list("--env", format_dict_for_cli(envs))
         full_cmd.add_args_list("--env-file", env_files)
@@ -1693,6 +1698,7 @@ class ContainerCLI(DockerCLICaller):
         self,
         containers: Union[ValidContainer, List[ValidContainer]],
         attach: bool = False,
+        detach_keys: Optional[str] = None,
         interactive: bool = False,
         stream: bool = False,
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
@@ -1704,6 +1710,7 @@ class ContainerCLI(DockerCLICaller):
         Parameters:
             containers: One or a list of containers.
             attach: Attach stdout/stderr and forward signals.
+            detach_keys: Key sequence for detaching from the container.
             interactive: Attach stdin (ensure it is open).
             stream: Stream output as a generator.
         """
@@ -1720,6 +1727,7 @@ class ContainerCLI(DockerCLICaller):
             )
         full_cmd = self.docker_cmd + ["container", "start"]
         full_cmd.add_flag("--attach", attach)
+        full_cmd.add_simple_arg("--detach-keys", detach_keys)
         full_cmd.add_flag("--interactive", interactive)
         full_cmd += containers
 

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -268,7 +268,6 @@ class Container(ReloadableObjectFromJson):
         self,
         command: List[str],
         detach: bool = False,
-        detach_keys: Optional[str] = None,
         envs: Dict[str, str] = {},
         env_files: Union[ValidPath, List[ValidPath]] = [],
         interactive: bool = False,
@@ -277,6 +276,7 @@ class Container(ReloadableObjectFromJson):
         user: Optional[str] = None,
         workdir: Optional[ValidPath] = None,
         stream: bool = False,
+        detach_keys: Optional[str] = None,
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
         """Execute a command in this container
 
@@ -287,7 +287,6 @@ class Container(ReloadableObjectFromJson):
             self,
             command,
             detach,
-            detach_keys,
             envs,
             env_files,
             interactive,
@@ -296,6 +295,7 @@ class Container(ReloadableObjectFromJson):
             user,
             workdir,
             stream,
+            detach_keys,
         )
 
     def exists(self) -> bool:
@@ -391,9 +391,9 @@ class Container(ReloadableObjectFromJson):
     def start(
         self,
         attach: bool = False,
-        detach_keys: Optional[str] = None,
         interactive: bool = False,
         stream: bool = False,
+        detach_keys: Optional[str] = None,
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
         """Starts this container.
 
@@ -401,7 +401,7 @@ class Container(ReloadableObjectFromJson):
         information about the arguments.
         """
         return ContainerCLI(self.client_config).start(
-            self, attach, detach_keys, interactive, stream
+            self, attach, interactive, stream, detach_keys
         )
 
     def stop(self, time: Union[int, timedelta] = None) -> None:
@@ -835,7 +835,6 @@ class ContainerCLI(DockerCLICaller):
         container: ValidContainer,
         command: List[str],
         detach: bool = False,
-        detach_keys: Optional[str] = None,
         envs: Dict[str, str] = {},
         env_files: Union[ValidPath, List[ValidPath]] = [],
         interactive: bool = False,
@@ -844,6 +843,7 @@ class ContainerCLI(DockerCLICaller):
         user: Optional[str] = None,
         workdir: Optional[ValidPath] = None,
         stream: bool = False,
+        detach_keys: Optional[str] = None,
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
         """Execute a command inside a container
 
@@ -854,7 +854,6 @@ class ContainerCLI(DockerCLICaller):
             command: The command to execute.
             detach: if `True`, returns immediately with `None`. If `False`,
                 returns the command stdout as string.
-            detach_keys: Override the key sequence for detaching a container.
             envs: Set environment variables
             env_files: Read one or more files of environment variables
             interactive: Leave stdin open during the duration of the process
@@ -867,6 +866,7 @@ class ContainerCLI(DockerCLICaller):
             user: Username or UID, format: `"<name|uid>[:<group|gid>]"`
             workdir: Working directory inside the container
             stream: Similar to `docker.run(..., stream=True)`.
+            detach_keys: Override the key sequence for detaching a container.
 
         Returns:
             Optional[str]
@@ -1710,9 +1710,9 @@ class ContainerCLI(DockerCLICaller):
         self,
         containers: Union[ValidContainer, List[ValidContainer]],
         attach: bool = False,
-        detach_keys: Optional[str] = None,
         interactive: bool = False,
         stream: bool = False,
+        detach_keys: Optional[str] = None,
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
         """Starts one or more created/stopped containers.
 
@@ -1722,9 +1722,9 @@ class ContainerCLI(DockerCLICaller):
         Parameters:
             containers: One or a list of containers.
             attach: Attach stdout/stderr and forward signals.
-            detach_keys: Override the key sequence for detaching a container.
             interactive: Attach stdin (ensure it is open).
             stream: Stream output as a generator.
+            detach_keys: Override the key sequence for detaching a container.
         """
         containers = to_list(containers)
         if containers == []:

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -393,14 +393,16 @@ class Container(ReloadableObjectFromJson):
         attach: bool = False,
         detach_keys: Optional[str] = None,
         interactive: bool = False,
-        stream: bool = False
+        stream: bool = False,
     ) -> Union[None, str, Iterable[Tuple[str, bytes]]]:
         """Starts this container.
 
         See the [`docker.container.start`](../sub-commands/container.md#start) command for
         information about the arguments.
         """
-        return ContainerCLI(self.client_config).start(self, attach, detach_keys, interactive, stream)
+        return ContainerCLI(self.client_config).start(
+            self, attach, detach_keys, interactive, stream
+        )
 
     def stop(self, time: Union[int, timedelta] = None) -> None:
         """Stops this container.

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -733,10 +733,10 @@ def test_kill_nothing(ctr_client: DockerClient):
 
 @patch("python_on_whales.components.container.cli_wrapper.run")
 def test_start_detach_keys(run_mock: Mock):
-    docker.start("container", ["cmd"], detach_keys="a,b")
+    docker.start("ctr_name", detach_keys="a,b")
     run_mock.assert_called_once_with(
         docker.client_config.docker_cmd
-        + ["container", "start", "--detach-keys", "a,b", "container", "cmd"]
+        + ["container", "start", "--detach-keys", "a,b", "ctr_name"]
     )
 
 
@@ -760,10 +760,11 @@ def test_exec_env_file(ctr_client: DockerClient, tmp_path: Path):
 
 @patch("python_on_whales.components.container.cli_wrapper.run")
 def test_exec_detach_keys(run_mock: Mock):
-    docker.execute("container", ["cmd"], detach_keys="a,b")
+    docker.execute("ctr_name", ["cmd"], detach_keys="a,b")
     run_mock.assert_called_once_with(
         docker.client_config.docker_cmd
-        + ["exec", "--detach-keys", "a,b", "container", "cmd"]
+        + ["exec", "--detach-keys", "a,b", "ctr_name", "cmd"],
+        tty=False,
     )
 
 

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -733,12 +733,10 @@ def test_kill_nothing(ctr_client: DockerClient):
 
 @patch("python_on_whales.components.container.cli_wrapper.run")
 def test_start_detach_keys(run_mock: Mock):
-    test_container_name = "container"
-    docker.start(test_container_name, ["echo", "dodo"], detach_keys="a,b")
+    docker.start("container", ["cmd"], detach_keys="a,b")
     run_mock.assert_called_once_with(
-        docker.client_config.docker_cmd + [
-            "container", "start", "--detach-keys", "a,b", test_container_name
-        ]
+        docker.client_config.docker_cmd
+        + ["container", "start", "--detach-keys", "a,b", "container", "cmd"]
     )
 
 
@@ -762,12 +760,10 @@ def test_exec_env_file(ctr_client: DockerClient, tmp_path: Path):
 
 @patch("python_on_whales.components.container.cli_wrapper.run")
 def test_exec_detach_keys(run_mock: Mock):
-    test_container_name = "container"
-    docker.execute(test_container_name, ["echo", "dodo"], detach_keys="a,b")
+    docker.execute("container", ["cmd"], detach_keys="a,b")
     run_mock.assert_called_once_with(
-        docker.client_config.docker_cmd + [
-            "exec", "--detach-keys", "a,b", test_container_name
-        ]
+        docker.client_config.docker_cmd
+        + ["exec", "--detach-keys", "a,b", "container", "cmd"]
     )
 
 

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -731,6 +731,17 @@ def test_kill_nothing(ctr_client: DockerClient):
         assert set_of_containers == set(ctr_client.ps())
 
 
+@patch("python_on_whales.components.container.cli_wrapper.run")
+def test_start_detach_keys(run_mock: Mock):
+    test_container_name = "container"
+    docker.start(test_container_name, ["echo", "dodo"], detach_keys="a,b")
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_cmd + [
+            "container", "start", "--detach-keys", "a,b", test_container_name
+        ]
+    )
+
+
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_exec_env(ctr_client: DockerClient):
     with ctr_client.run("ubuntu", ["sleep", "infinity"], detach=True, remove=True) as c:
@@ -747,6 +758,17 @@ def test_exec_env_file(ctr_client: DockerClient, tmp_path: Path):
     with ctr_client.run("ubuntu", ["sleep", "infinity"], detach=True, remove=True) as c:
         result = c.execute(["bash", "-c", "echo $DODO"], env_files=[env_file])
     assert result == "dada"
+
+
+@patch("python_on_whales.components.container.cli_wrapper.run")
+def test_exec_detach_keys(run_mock: Mock):
+    test_container_name = "container"
+    docker.execute(test_container_name, ["echo", "dodo"], detach_keys="a,b")
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_cmd + [
+            "exec", "--detach-keys", "a,b", test_container_name
+        ]
+    )
 
 
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)


### PR DESCRIPTION
- [`docker start`](https://docs.docker.com/engine/reference/commandline/container_start/#options)
- [`docker exec`](https://docs.docker.com/engine/reference/commandline/container_exec/#options)
Also supported with `podman`.

UT just checks the args are passed correctly.
