### PR TITLE
Add stream output for pruning

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1159,11 +1159,31 @@ class ContainerCLI(DockerCLICaller):
 
         run(full_cmd)
 
-    def prune(self, filters: Dict[str, str] = {}) -> None:
+    @overload
+    def prune(
+        self,
+        filters: Dict[str, str] = {},
+        stream_logs: Literal[True] = ...,
+    ) -> Iterable[Tuple[str, bytes]]: ...
+
+    @overload
+    def prune(
+        self,
+        filters: Dict[str, str] = {},
+        stream_logs: Literal[False] = ...,
+    ) -> None: ...
+
+    def prune(
+        self,
+        filters: Dict[str, str] = {},
+        stream_logs: bool = False,
+    ):
         """Remove containers that are not running.
 
         Parameters:
             filters: Filters as strings or list of strings
+            stream_logs: If `True` this function will return an iterator of strings.
+                You can then read the logs as they arrive.
         """
         if isinstance(filter, list):
             raise TypeError(
@@ -1173,6 +1193,8 @@ class ContainerCLI(DockerCLICaller):
             )
         full_cmd = self.docker_cmd + ["container", "prune", "--force"]
         full_cmd.add_args_list("--filter", format_dict_for_cli(filters))
+        if stream_logs:
+            return stream_stdout_and_stderr(full_cmd)
         run(full_cmd)
 
     def rename(self, container: ValidContainer, new_name: str) -> None:
@@ -1931,12 +1953,10 @@ class ContainerCLI(DockerCLICaller):
         run(full_cmd)
 
     @overload
-    def wait(self, x: ValidContainer) -> int:
-        ...
+    def wait(self, x: ValidContainer) -> int: ...
 
     @overload
-    def wait(self, x: List[ValidContainer]) -> List[int]:
-        ...
+    def wait(self, x: List[ValidContainer]) -> List[int]: ...
 
     def wait(
         self, x: Union[ValidContainer, List[ValidContainer]]

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1185,7 +1185,9 @@ class ContainerCLI(DockerCLICaller):
         Parameters:
             filters: Filters as strings or list of strings
             stream_logs: If `True` this function will return an iterator of strings.
-                You can then read the logs as they arrive.
+                You can then read the logs as they arrive. If `False` (the default value), then
+                the function returns `None`, but when it returns, then the prune operation has already been
+                done.
         """
         if isinstance(filter, list):
             raise TypeError(

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -983,10 +983,12 @@ class ContainerCLI(DockerCLICaller):
             run(full_cmd)
 
     @overload
-    def inspect(self, x: ValidContainer, /) -> Container: ...
+    def inspect(self, x: ValidContainer, /) -> Container:
+        ...
 
     @overload
-    def inspect(self, x: List[ValidContainer], /) -> List[Container]: ...
+    def inspect(self, x: List[ValidContainer], /) -> List[Container]:
+        ...
 
     def inspect(
         self, x: Union[ValidContainer, List[ValidContainer]], /

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1164,14 +1164,16 @@ class ContainerCLI(DockerCLICaller):
         self,
         filters: Dict[str, str] = {},
         stream_logs: Literal[True] = ...,
-    ) -> Iterable[Tuple[str, bytes]]: ...
+    ) -> Iterable[Tuple[str, bytes]]:
+        ...
 
     @overload
     def prune(
         self,
         filters: Dict[str, str] = {},
         stream_logs: Literal[False] = ...,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     def prune(
         self,
@@ -1953,10 +1955,12 @@ class ContainerCLI(DockerCLICaller):
         run(full_cmd)
 
     @overload
-    def wait(self, x: ValidContainer) -> int: ...
+    def wait(self, x: ValidContainer) -> int:
+        ...
 
     @overload
-    def wait(self, x: List[ValidContainer]) -> List[int]: ...
+    def wait(self, x: List[ValidContainer]) -> List[int]:
+        ...
 
     def wait(
         self, x: Union[ValidContainer, List[ValidContainer]]

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -983,12 +983,10 @@ class ContainerCLI(DockerCLICaller):
             run(full_cmd)
 
     @overload
-    def inspect(self, x: ValidContainer, /) -> Container:
-        ...
+    def inspect(self, x: ValidContainer, /) -> Container: ...
 
     @overload
-    def inspect(self, x: List[ValidContainer], /) -> List[Container]:
-        ...
+    def inspect(self, x: List[ValidContainer], /) -> List[Container]: ...
 
     def inspect(
         self, x: Union[ValidContainer, List[ValidContainer]], /

--- a/python_on_whales/components/task/cli_wrapper.py
+++ b/python_on_whales/components/task/cli_wrapper.py
@@ -90,7 +90,7 @@ class Task(ReloadableObjectFromJson):
         return self._get_inspect_result().desired_state
 
     def __repr__(self):
-        return f"python_on_whales.Image(id='{self.id[:12]}', name={self.name})"
+        return f"python_on_whales.Task(id='{self.id[:12]}', name={self.name})"
 
 
 class TaskCLI(DockerCLICaller):

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -957,7 +957,7 @@ def test_prune_streaming(ctr_client: DockerClient):
     logs = list(ctr_client.container.prune(filters={"label": "dne"}, stream_logs=True))
     assert container in ctr_client.container.list(all=True)
 
-    assert len(logs) >= 1
+    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else True
     logs_as_big_binary = b""
     for log_type, log_value in logs:
         assert log_type in ("stdout", "stderr")

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -940,11 +940,8 @@ def test_prune_streaming(ctr_client: DockerClient):
         assert len(logs) >= 1
     logs_as_big_binary = b""
     for log_type, log_value in logs:
-        assert (
-            (log_type in ("stdout", "stderr"))
-            if ctr_client.client_config.client_type == "docker"
-            else True
-        )
+         if ctr_client.client_config.client_type == "docker":
+             assert log_type in ("stdout", "stderr")
 
         logs_as_big_binary += log_value
     assert (

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -946,8 +946,11 @@ def test_prune_streaming(ctr_client: DockerClient):
         )
 
         logs_as_big_binary += log_value
-        print(log_type, log_value)
-    assert b"Total reclaimed space:" in logs_as_big_binary
+    assert (
+        b"Total reclaimed space:" in logs_as_big_binary
+        if ctr_client.client_config.client_type == "docker"
+        else True
+    )
 
     # container not pruned because it is does not have label "dne"
     # podman does not provide logs when not pruned
@@ -959,8 +962,12 @@ def test_prune_streaming(ctr_client: DockerClient):
     for log_type, log_value in logs:
         assert log_type in ("stdout", "stderr")
         logs_as_big_binary += log_value
-        print(log_type, log_value)
-    assert b"Total reclaimed space:" in logs_as_big_binary
+
+    assert (
+        b"Total reclaimed space:" in logs_as_big_binary
+        if ctr_client.client_config.client_type == "docker"
+        else True
+    )
 
     # container not pruned because it is not old enough and does not have label "dne"
     # podman does not provide logs when not pruned
@@ -980,8 +987,12 @@ def test_prune_streaming(ctr_client: DockerClient):
             else True
         )
         logs_as_big_binary += log_value
-        print(log_type, log_value)
-    assert b"Total reclaimed space:" in logs_as_big_binary
+
+    assert (
+        b"Total reclaimed space:" in logs_as_big_binary
+        if ctr_client.client_config.client_type == "docker"
+        else True
+    )
 
     # container pruned
     # podman does provide logs when pruned
@@ -991,14 +1002,22 @@ def test_prune_streaming(ctr_client: DockerClient):
     assert (
         len(logs) >= 3
         if ctr_client.client_config.client_type == "docker"
-        else len(logs) >= 1  # podman
+        else len(logs) >= 1  # podman only
     )
     logs_as_big_binary = b""
     for log_type, log_value in logs:
-        assert log_type in ("stdout", "stderr")
+        assert (
+            log_type in ("stdout", "stderr")
+            if ctr_client.client_config.client_type == "docker"
+            else True
+        )
         logs_as_big_binary += log_value
-        print(log_type, log_value)
-    assert b"Deleted Containers:" in logs_as_big_binary
+
+    assert (
+        b"Deleted Containers:" in logs_as_big_binary
+        if ctr_client.client_config.client_type == "docker"
+        else True
+    )
 
 
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -958,11 +958,8 @@ def test_prune_streaming(ctr_client: DockerClient):
         assert log_type in ("stdout", "stderr")
         logs_as_big_binary += log_value
 
-    assert (
-        b"Total reclaimed space:" in logs_as_big_binary
-        if ctr_client.client_config.client_type == "docker"
-        else True
-    )
+    if ctr_client.client_config.client_type == "docker":
+        assert b"Total reclaimed space:" in logs_as_big_binary
 
     # container not pruned because it is not old enough and does not have label "dne"
     # podman does not provide logs when not pruned

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -944,11 +944,8 @@ def test_prune_streaming(ctr_client: DockerClient):
              assert log_type in ("stdout", "stderr")
 
         logs_as_big_binary += log_value
-    assert (
-        b"Total reclaimed space:" in logs_as_big_binary
-        if ctr_client.client_config.client_type == "docker"
-        else True
-    )
+    if ctr_client.client_config.client_type == "docker":
+        assert b"Total reclaimed space:" in logs_as_big_binary
 
     # container not pruned because it is does not have label "dne"
     # podman does not provide logs when not pruned

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -936,7 +936,8 @@ def test_prune_streaming(ctr_client: DockerClient):
     logs = list(ctr_client.container.prune(filters={"until": "100h"}, stream_logs=True))
     assert container in ctr_client.container.list(all=True)
 
-    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else True
+    if ctr_client.client_config.client_type == "docker":
+        assert len(logs) >= 1
     logs_as_big_binary = b""
     for log_type, log_value in logs:
         assert (

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -936,14 +936,15 @@ def test_prune_streaming(ctr_client: DockerClient):
     logs = list(ctr_client.container.prune(filters={"until": "100h"}, stream_logs=True))
     assert container in ctr_client.container.list(all=True)
 
-    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else 0
+    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else True
     logs_as_big_binary = b""
     for log_type, log_value in logs:
         assert (
-            log_type in ("stdout", "stderr")
+            (log_type in ("stdout", "stderr"))
             if ctr_client.client_config.client_type == "docker"
-            else ()
+            else True
         )
+
         logs_as_big_binary += log_value
         print(log_type, log_value)
     assert b"Total reclaimed space:" in logs_as_big_binary
@@ -970,13 +971,13 @@ def test_prune_streaming(ctr_client: DockerClient):
     )
     assert container in ctr_client.container.list(all=True)
 
-    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else 0
+    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else True
     logs_as_big_binary = b""
     for log_type, log_value in logs:
         assert (
             log_type in ("stdout", "stderr")
             if ctr_client.client_config.client_type == "docker"
-            else ()
+            else True
         )
         logs_as_big_binary += log_value
         print(log_type, log_value)
@@ -987,7 +988,11 @@ def test_prune_streaming(ctr_client: DockerClient):
     logs = list(ctr_client.container.prune(stream_logs=True))
     assert container not in ctr_client.container.list(all=True)
 
-    assert len(logs) >= 3
+    assert (
+        len(logs) >= 3
+        if ctr_client.client_config.client_type == "docker"
+        else len(logs) >= 1  # podman
+    )
     logs_as_big_binary = b""
     for log_type, log_value in logs:
         assert log_type in ("stdout", "stderr")

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -940,10 +940,10 @@ def test_prune_streaming(ctr_client: DockerClient):
         assert len(logs) >= 1
     logs_as_big_binary = b""
     for log_type, log_value in logs:
-         if ctr_client.client_config.client_type == "docker":
-             assert log_type in ("stdout", "stderr")
+        if ctr_client.client_config.client_type == "docker":
+            assert log_type in ("stdout", "stderr")
+            logs_as_big_binary += log_value
 
-        logs_as_big_binary += log_value
     if ctr_client.client_config.client_type == "docker":
         assert b"Total reclaimed space:" in logs_as_big_binary
 
@@ -952,11 +952,13 @@ def test_prune_streaming(ctr_client: DockerClient):
     logs = list(ctr_client.container.prune(filters={"label": "dne"}, stream_logs=True))
     assert container in ctr_client.container.list(all=True)
 
-    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else True
+    if ctr_client.client_config.client_type == "docker":
+        assert len(logs) >= 1
     logs_as_big_binary = b""
     for log_type, log_value in logs:
-        assert log_type in ("stdout", "stderr")
-        logs_as_big_binary += log_value
+        if ctr_client.client_config.client_type == "docker":
+            assert log_type in ("stdout", "stderr")
+            logs_as_big_binary += log_value
 
     if ctr_client.client_config.client_type == "docker":
         assert b"Total reclaimed space:" in logs_as_big_binary
@@ -970,46 +972,36 @@ def test_prune_streaming(ctr_client: DockerClient):
     )
     assert container in ctr_client.container.list(all=True)
 
-    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else True
+    if ctr_client.client_config.client_type == "docker":
+        assert len(logs) >= 1
     logs_as_big_binary = b""
     for log_type, log_value in logs:
-        assert (
-            log_type in ("stdout", "stderr")
-            if ctr_client.client_config.client_type == "docker"
-            else True
-        )
+        if ctr_client.client_config.client_type == "docker":
+            assert log_type in ("stdout", "stderr")
         logs_as_big_binary += log_value
 
-    assert (
-        b"Total reclaimed space:" in logs_as_big_binary
-        if ctr_client.client_config.client_type == "docker"
-        else True
-    )
+    if ctr_client.client_config.client_type == "docker":
+        assert b"Total reclaimed space:" in logs_as_big_binary
 
     # container pruned
     # podman does provide logs when pruned
     logs = list(ctr_client.container.prune(stream_logs=True))
     assert container not in ctr_client.container.list(all=True)
 
-    assert (
+    if ctr_client.client_config.client_type == "docker":
         len(logs) >= 3
-        if ctr_client.client_config.client_type == "docker"
-        else len(logs) >= 1  # podman only
-    )
+
+    if ctr_client.client_config.client_type == "podman":
+        len(logs) >= 1
+
     logs_as_big_binary = b""
     for log_type, log_value in logs:
-        assert (
-            log_type in ("stdout", "stderr")
-            if ctr_client.client_config.client_type == "docker"
-            else True
-        )
+        if ctr_client.client_config.client_type == "docker":
+            assert log_type in ("stdout", "stderr")
         logs_as_big_binary += log_value
 
-    assert (
-        b"Deleted Containers:" in logs_as_big_binary
-        if ctr_client.client_config.client_type == "docker"
-        else True
-    )
+    if ctr_client.client_config.client_type == "docker":
+        assert b"Total reclaimed space:" in logs_as_big_binary
 
 
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -932,18 +932,24 @@ def test_prune_streaming(ctr_client: DockerClient):
     assert container in ctr_client.container.list(all=True)
 
     # container not pruned because it is not old enough
+    # podman does not provide logs when not pruned
     logs = list(ctr_client.container.prune(filters={"until": "100h"}, stream_logs=True))
     assert container in ctr_client.container.list(all=True)
 
-    assert len(logs) >= 1
+    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else 0
     logs_as_big_binary = b""
     for log_type, log_value in logs:
-        assert log_type in ("stdout", "stderr")
+        assert (
+            log_type in ("stdout", "stderr")
+            if ctr_client.client_config.client_type == "docker"
+            else ()
+        )
         logs_as_big_binary += log_value
         print(log_type, log_value)
     assert b"Total reclaimed space:" in logs_as_big_binary
 
     # container not pruned because it is does not have label "dne"
+    # podman does not provide logs when not pruned
     logs = list(ctr_client.container.prune(filters={"label": "dne"}, stream_logs=True))
     assert container in ctr_client.container.list(all=True)
 
@@ -956,6 +962,7 @@ def test_prune_streaming(ctr_client: DockerClient):
     assert b"Total reclaimed space:" in logs_as_big_binary
 
     # container not pruned because it is not old enough and does not have label "dne"
+    # podman does not provide logs when not pruned
     logs = list(
         ctr_client.container.prune(
             filters={"until": "100h", "label": "dne"}, stream_logs=True
@@ -963,15 +970,20 @@ def test_prune_streaming(ctr_client: DockerClient):
     )
     assert container in ctr_client.container.list(all=True)
 
-    assert len(logs) >= 1
+    assert len(logs) >= 1 if ctr_client.client_config.client_type == "docker" else 0
     logs_as_big_binary = b""
     for log_type, log_value in logs:
-        assert log_type in ("stdout", "stderr")
+        assert (
+            log_type in ("stdout", "stderr")
+            if ctr_client.client_config.client_type == "docker"
+            else ()
+        )
         logs_as_big_binary += log_value
         print(log_type, log_value)
     assert b"Total reclaimed space:" in logs_as_big_binary
 
     # container pruned
+    # podman does provide logs when pruned
     logs = list(ctr_client.container.prune(stream_logs=True))
     assert container not in ctr_client.container.list(all=True)
 


### PR DESCRIPTION
Resolves #396 
Not sure if we need to update this? https://github.com/gabrieldemarmiesse/python-on-whales/issues/499

- added function overloading for pruning
- added relevant tests to check the streaming logs/output

Will complete the overloading for other pruning, such as for Docker Image, Network, Buildx, etc. when this one gets approved.