### PR TITLE
Function docker.compose.down does not accept optional list of service names #570 

### DIFF
--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -508,6 +508,8 @@ class BuildxCLI(DockerCLICaller):
         # if the line starts by a " ", it's not a builder, it's a node
         lines = list(filter(lambda x: not x.startswith(" "), lines))
         builders_names = [x.split(" ")[0] for x in lines]
+        # in buildx 0.13.0, the "*" is added to the name, without whitespace
+        builders_names = [removesuffix(x, "*") for x in builders_names]
         return [
             Builder(self.client_config, x, is_immutable_id=True) for x in builders_names
         ]
@@ -588,6 +590,16 @@ class BuildxCLI(DockerCLICaller):
         full_cmd = self.docker_cmd + ["buildx", "--help"]
         help_output = run(full_cmd)
         return "buildx" in help_output
+
+
+def removesuffix(base_string: str, suffix: str) -> str:
+    """Backport of removesuffix for python <3.9.
+
+    TODO: Remove this when we drop support for python 3.8.
+    """
+    if base_string.endswith(suffix):
+        return base_string[: -len(suffix)]
+    return base_string
 
 
 def format_dict_for_buildx(options: Dict[str, str]) -> str:

--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -209,6 +209,7 @@ class ComposeCLI(DockerCLICaller):
     @overload
     def down(
         self,
+        services: Union[List[str], str, None] = ...,
         remove_orphans: bool = ...,
         remove_images: Optional[str] = ...,
         timeout: Optional[int] = ...,
@@ -221,6 +222,7 @@ class ComposeCLI(DockerCLICaller):
     @overload
     def down(
         self,
+        services: Union[List[str], str, None] = ...,
         remove_orphans: bool = ...,
         remove_images: Optional[str] = ...,
         timeout: Optional[int] = ...,
@@ -232,6 +234,7 @@ class ComposeCLI(DockerCLICaller):
 
     def down(
         self,
+        services: Union[List[str], str, None] = None,
         remove_orphans: bool = False,
         remove_images: Optional[str] = None,
         timeout: Optional[int] = None,
@@ -242,6 +245,9 @@ class ComposeCLI(DockerCLICaller):
         """Stops and removes the containers
 
         Parameters:
+            services: The services to stop. If `None` (default), all services are
+                stopped. If an empty list is provided, the function call does nothing, it's
+                a no-op.
             remove_orphans: Remove containers for services not defined in
                 the Compose file.
             remove_images: Remove images used by services.
@@ -265,6 +271,12 @@ class ComposeCLI(DockerCLICaller):
         full_cmd.add_simple_arg("--rmi", remove_images)
         full_cmd.add_simple_arg("--timeout", timeout)
         full_cmd.add_flag("--volumes", volumes)
+
+        if services == []:
+            return
+        elif services is not None:
+            services = to_list(services)
+            full_cmd += services
 
         if stream_logs:
             return stream_stdout_and_stderr(full_cmd)

--- a/scripts/download-docker-plugins.sh
+++ b/scripts/download-docker-plugins.sh
@@ -3,7 +3,7 @@
 set -e
 
 mkdir -p ~/.docker/cli-plugins/
-wget -q https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-linux-x86_64 -O ~/.docker/cli-plugins/docker-compose
+wget -q https://github.com/docker/compose/releases/download/v2.26.0/docker-compose-linux-x86_64 -O ~/.docker/cli-plugins/docker-compose
 chmod +x ~/.docker/cli-plugins/docker-compose
 wget -q https://github.com/docker/buildx/releases/download/v0.10.0/buildx-v0.10.0.linux-amd64 -O ~/.docker/cli-plugins/docker-buildx
 chmod +x ~/.docker/cli-plugins/docker-buildx

--- a/tests/python_on_whales/components/dummy_compose_with_container_names.yml
+++ b/tests/python_on_whales/components/dummy_compose_with_container_names.yml
@@ -1,0 +1,20 @@
+version: "3.7"
+
+services:
+
+  busybox:
+    container_name: busybox
+    image: busybox:latest
+    command: sleep infinity
+
+  alpine:
+    container_name: alpine
+    image: alpine:latest
+    command: sleep infinity
+    environment:
+     - DD_API_KEY=__your_datadog_api_key_here__
+     - POSTGRES_HOST_AUTH_METHOD=trust
+
+  dodo:
+    image: busybox:latest
+    entrypoint: /bin/sh

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -651,7 +651,7 @@ def test_config_complexe_compose():
     docker = DockerClient(compose_files=[compose_file], compose_compatibility=True)
     config = docker.compose.config()
 
-    assert config.services["my_service"].build.context == Path(
+    assert config.services["my_service"].build.context == (
         PROJECT_ROOT / "tests/python_on_whales/components/my_service_build"
     )
     assert config.services["my_service"].image == "some_random_image"

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime, timedelta
 from os import makedirs, remove
 from pathlib import Path
+from unittest import Mock, patch
 
 import pytest
 import pytz
@@ -184,6 +185,86 @@ def test_docker_compose_up_down_streaming():
 
     assert b"Removed" in logs_as_big_binary
     assert b"Container components_alpine_1" in logs_as_big_binary
+
+
+def test_docker_compose_down_services():
+    docker = DockerClient(
+        compose_files=[
+            PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
+        ],
+        compose_compatibility=True,
+    )
+    docker.compose.up(["busybox", "alpine"], detach=True)
+    assert len(docker.compose.ps()) == 2
+
+    output_of_down = docker.compose.down(services=["busybox"])
+    assert output_of_down is None
+    assert len(docker.compose.ps()) == 1
+    active_container = docker.compose.ps()[0]
+    assert active_container.name == "components_alpine_1"
+
+    output_of_down = docker.compose.down(services=["alpine"])
+    assert output_of_down is None
+    assert docker.compose.ps() == []
+
+
+def test_docker_compose_down_no_services():
+    docker = DockerClient(
+        compose_files=[
+            PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
+        ],
+        compose_compatibility=True,
+    )
+    docker.compose.up(["busybox", "alpine"], detach=True)
+    initial_containers = docker.compose.ps()
+    assert len(initial_containers) == 2
+
+    output_of_down = docker.compose.down(services=[])
+    assert output_of_down is None
+    final_containers = docker.compose.ps()
+    assert final_containers == initial_containers
+
+    output_of_down = docker.compose.down()
+    assert output_of_down is None
+    assert docker.compose.ps() == []
+
+
+@patch("python_on_whales.components.compose.cli_wrapper.run")
+def test_docker_compose_cli_down_all_services(run_mock: Mock):
+    docker.compose.down()
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_compose_cmd + ["down"],
+        capture_stderr=False,
+        capture_stdout=False,
+    )
+
+
+@patch("python_on_whales.components.compose.cli_wrapper.run")
+def test_docker_compose_cli_down_multiple_services(run_mock: Mock):
+    test_services = ["test_a", "test_b"]
+    docker.compose.down(services=test_services)
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_compose_cmd + ["down"] + test_services,
+        capture_stderr=False,
+        capture_stdout=False,
+    )
+
+
+@patch("python_on_whales.components.compose.cli_wrapper.run")
+def test_docker_compose_cli_down_single_service(run_mock: Mock):
+    test_service = "test_a"
+    docker.compose.down(services=test_service)
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_compose_cmd + ["down"] + [test_service],
+        capture_stderr=False,
+        capture_stdout=False,
+    )
+
+
+@patch("python_on_whales.components.compose.cli_wrapper.run")
+def test_docker_compose_cli_down_services_no_op(run_mock: Mock):
+    docker.compose.down(services=[])
+    run_mock.assert_not_called()
 
 
 def test_no_containers():

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -193,6 +193,7 @@ def test_docker_compose_down_services():
             PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
         ],
         compose_compatibility=True,
+        compose_project_name="testing",
     )
     docker.compose.up(["busybox", "alpine"], detach=True)
     assert len(docker.compose.ps()) == 2
@@ -201,7 +202,7 @@ def test_docker_compose_down_services():
     assert output_of_down is None
     assert len(docker.compose.ps()) == 1
     active_container = docker.compose.ps()[0]
-    assert active_container.name == "components_alpine_1"
+    assert active_container.name == "testing_alpine_1"
 
     output_of_down = docker.compose.down(services=["alpine"])
     assert output_of_down is None

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -651,7 +651,9 @@ def test_config_complexe_compose():
     docker = DockerClient(compose_files=[compose_file], compose_compatibility=True)
     config = docker.compose.config()
 
-    assert config.services["my_service"].build.context == Path("my_service_build")
+    assert config.services["my_service"].build.context == Path(
+        PROJECT_ROOT / "tests/python_on_whales/components/my_service_build"
+    )
     assert config.services["my_service"].image == "some_random_image"
     assert config.services["my_service"].command == [
         "ping",

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -5,7 +5,7 @@ import time
 from datetime import datetime, timedelta
 from os import makedirs, remove
 from pathlib import Path
-from unittest import Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 import pytz

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -190,11 +190,13 @@ def test_docker_compose_up_down_streaming():
 def test_docker_compose_down_services():
     docker = DockerClient(
         compose_files=[
-            PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
+            PROJECT_ROOT
+            / "tests/python_on_whales/components/dummy_compose_with_container_names.yml"
         ],
         compose_compatibility=True,
-        compose_project_name="testing",
+        compose_project_name="test_docker_compose_down_services",
     )
+
     docker.compose.up(["busybox", "alpine"], detach=True)
     assert len(docker.compose.ps()) == 2
 
@@ -202,7 +204,9 @@ def test_docker_compose_down_services():
     assert output_of_down is None
     assert len(docker.compose.ps()) == 1
     active_container = docker.compose.ps()[0]
-    assert active_container.name == "testing_alpine_1"
+    assert (
+        active_container.name == "alpine"
+    ), f"actual container name: {active_container.name}"
 
     output_of_down = docker.compose.down(services=["alpine"])
     assert output_of_down is None
@@ -212,9 +216,11 @@ def test_docker_compose_down_services():
 def test_docker_compose_down_no_services():
     docker = DockerClient(
         compose_files=[
-            PROJECT_ROOT / "tests/python_on_whales/components/dummy_compose.yml"
+            PROJECT_ROOT
+            / "tests/python_on_whales/components/dummy_compose_with_container_names.yml"
         ],
         compose_compatibility=True,
+        compose_project_name="test_docker_compose_down_no_services",
     )
     docker.compose.up(["busybox", "alpine"], detach=True)
     initial_containers = docker.compose.ps()


### PR DESCRIPTION
Hi 😃 

Here follow the proposed changes regarding issue #570.
Now the following calls are possible:

```python
from python_on_whales import docker

# ...

docker.compose.down(services=[])  # no-op - does nothing
docker.compose.down(services="a")  # stops service "a"
docker.compose.down(services=["b", "c"])  # stops services "b" and "c"
docker.compose.down()  # default - stops all services
```

- Unit tests included
- Documentation updated