### PR TITLE
Improve typing for `DockerClient.compose.config`

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -107,6 +107,14 @@ class ComposeCLI(DockerCLICaller):
         else:
             run(full_cmd, capture_stdout=False)
 
+    @overload
+    def config(self, return_json: Literal[False] = ...) -> ComposeConfig:
+        ...
+
+    @overload
+    def config(self, return_json: Literal[True] = ...) -> Dict[str, Any]:
+        ...
+
     def config(self, return_json: bool = False) -> Union[ComposeConfig, Dict[str, Any]]:
         """Returns the configuration of the compose stack for further inspection.
 


### PR DESCRIPTION
Added overloads to make typing more exact by evaluating the truthiness of `return_json`