### PR TITLE
Support podman's `--preserve-fds` arg to container run/exec

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -863,7 +863,6 @@ class ContainerCLI(DockerCLICaller):
                 on the terminal.
             preserve_fds: The number of additional file descriptors to pass
                 through to the container. Only supported by podman.
-
             privileged: Give extended privileges to the container.
             tty: Allocate a pseudo-TTY. Allow the process to access your terminal
                 to write on it.
@@ -940,6 +939,9 @@ class ContainerCLI(DockerCLICaller):
             full_cmd.append(arg)
 
         if preserve_fds:
+            # Pass through additional file descriptors (as well as 0-2,
+            # stdin, stdout, stderr, which are handled separately by the
+            # container runtime). See the podman documentation.
             pass_fds = range(3, 3 + preserve_fds)
         else:
             pass_fds = ()
@@ -1741,6 +1743,9 @@ class ContainerCLI(DockerCLICaller):
                 )
 
         if preserve_fds:
+            # Pass through additional file descriptors (as well as 0-2,
+            # stdin, stdout, stderr, which are handled separately by the
+            # container runtime). See the podman documentation.
             pass_fds = range(3, 3 + preserve_fds)
         else:
             pass_fds = ()

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -786,6 +786,7 @@ def test_exec_detach_keys(run_mock: Mock):
         docker.client_config.docker_cmd
         + ["exec", "--detach-keys", "a,b", "ctr_name", "cmd"],
         tty=False,
+        pass_fds=(),
     )
 
 
@@ -1164,6 +1165,7 @@ def test_run_default_pull(image_mock: Mock, _: Mock, run_mock: Mock):
         docker.client_config.docker_cmd + ["container", "run", test_image_name],
         tty=False,
         capture_stderr=False,
+        pass_fds=(),
     )
 
 
@@ -1184,6 +1186,7 @@ def test_run_missing_pull(image_mock: Mock, _: Mock, run_mock: Mock):
         docker.client_config.docker_cmd + ["container", "run", test_image_name],
         tty=False,
         capture_stderr=False,
+        pass_fds=(),
     )
 
 
@@ -1204,6 +1207,7 @@ def test_run_always_pull(image_mock: Mock, _: Mock, run_mock: Mock):
         docker.client_config.docker_cmd + ["container", "run", test_image_name],
         tty=False,
         capture_stderr=False,
+        pass_fds=(),
     )
 
 
@@ -1225,6 +1229,7 @@ def test_run_never_pull(image_mock: Mock, _: Mock, run_mock: Mock):
         + ["container", "run", "--pull", "never", test_image_name],
         tty=False,
         capture_stderr=False,
+        pass_fds=(),
     )
 
 

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -220,6 +220,10 @@ def test_create_with_systemd_mode(podman_client: DockerClient):
 
 def test_run_with_preserve_fds(podman_client: DockerClient):
     read_fd, write_fd = os.pipe()
+    # Pass through enough additional file descriptors (as well as 0-2, stdin,
+    # stdout, stderr, which are handled separately by the container runtime) to
+    # ensure the write fd is available to the container.
+    # See the podman documentation.
     with podman_client.container.run(
         "ubuntu",
         ["bash", "-c", f"echo foobar >&{write_fd}"],

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -218,6 +218,17 @@ def test_create_with_systemd_mode(podman_client: DockerClient):
         assert container.config.systemd_mode is True
 
 
+def test_run_with_preserve_fds(podman_client: DockerClient):
+    read_fd, write_fd = os.pipe()
+    with podman_client.container.run(
+        "ubuntu",
+        ["bash", "-c", f"echo foobar >&{write_fd}"],
+        detach=True,
+        preserve_fds=write_fd - 2,
+    ):
+        assert os.read(read_fd, 7) == b"foobar\n"
+
+
 @pytest.mark.parametrize(
     "ctr_client",
     ["docker", pytest.param("podman", marks=pytest.mark.xfail)],


### PR DESCRIPTION
Tested manually, but should probably add a testcase too... need to figure out the best way to do so.

- [x] Add testcase