### PR TITLE
Allow `podman exec` with `--interactive` and no `--tty`

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -904,13 +904,6 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_args_list("--env", format_dict_for_cli(envs))
         full_cmd.add_args_list("--env-file", env_files)
 
-        # TODO: activate interactive and tty
-        if interactive and not tty:
-            raise NotImplementedError(
-                "Currently, docker.container.execute(interactive=True) must have"
-                "tty=True. interactive=True and tty=False is not yet implemented."
-            )
-
         if interactive and stream:
             raise ValueError(
                 "You can't set interactive=True and stream=True at the same"

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -876,7 +876,7 @@ def test_exec_interactive_and_tty(ctr_client: DockerClient):
         tty =  c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=True)
 
         assert no_tty == ""
-        assert tty == "bash: hi: command not found"
+        assert tty == "/bin/bash: hi: command not found"
 
 @pytest.mark.parametrize(
     "method",

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -875,7 +875,7 @@ def test_exec_interactive_no_tty(ctr_client: DockerClient):
         with pytest.raises(DockerException) as no_tty_exc:
             c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=False)
         assert no_tty_exc.value.stdout == ""
-        assert no_tty_exc.value.stderr == "/bin/bash: hi: command not found"
+        assert "hi: command not found" in no_tty_exc.value.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -872,11 +872,12 @@ def test_exec_change_directory(ctr_client: DockerClient):
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_exec_interactive_and_tty(ctr_client: DockerClient):
     with ctr_client.run("ubuntu", ["sleep", "infinity"], detach=True, remove=True) as c:
-        no_tty =  c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=False)
-        tty =  c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=True)
+        no_tty = c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=False)
+        tty = c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=True)
 
         assert no_tty == ""
         assert tty == "/bin/bash: hi: command not found"
+
 
 @pytest.mark.parametrize(
     "method",

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -870,15 +870,12 @@ def test_exec_change_directory(ctr_client: DockerClient):
 
 
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
-def test_exec_interactive_and_tty(ctr_client: DockerClient):
+def test_exec_interactive_no_tty(ctr_client: DockerClient):
     with ctr_client.run("ubuntu", ["sleep", "infinity"], detach=True, remove=True) as c:
         with pytest.raises(DockerException) as no_tty_exc:
             c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=False)
         assert no_tty_exc.value.stdout == ""
-
-        with pytest.raises(DockerException) as tty_exc:
-            c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=True)
-        assert tty_exc.value.stdout == "/bin/bash: hi: command not found"
+        assert no_tty_exc.value.stderr == "/bin/bash: hi: command not found"
 
 
 @pytest.mark.parametrize(

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -869,6 +869,15 @@ def test_exec_change_directory(ctr_client: DockerClient):
         assert c.execute(["pwd"], workdir="/usr/lib") == "/usr/lib"
 
 
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
+def test_exec_interactive_and_tty(ctr_client: DockerClient):
+    with ctr_client.run("ubuntu", ["sleep", "infinity"], detach=True, remove=True) as c:
+        no_tty =  c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=False)
+        tty =  c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=True)
+
+        assert no_tty == ""
+        assert tty == "bash: hi: command not found"
+
 @pytest.mark.parametrize(
     "method",
     [

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -872,11 +872,13 @@ def test_exec_change_directory(ctr_client: DockerClient):
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_exec_interactive_and_tty(ctr_client: DockerClient):
     with ctr_client.run("ubuntu", ["sleep", "infinity"], detach=True, remove=True) as c:
-        no_tty = c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=False)
-        tty = c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=True)
+        with pytest.raises(DockerException) as no_tty_exc:
+            c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=False)
+        assert no_tty_exc.value.stdout == ""
 
-        assert no_tty == ""
-        assert tty == "/bin/bash: hi: command not found"
+        with pytest.raises(DockerException) as tty_exc:
+            c.execute(["/bin/bash", "-c", "hi"], interactive=True, tty=True)
+        assert tty_exc.value.stdout == "/bin/bash: hi: command not found"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
An interactive container does not need to have a TTY. There's a slight difference in behaviour that is currently a blocker for my use case.

```
>podman exec -i ctr_name /bin/bash -c 'hi' 1> 1.txt 2> 2.txt
>cat 1.txt
>cat 2.txt
/bin/bash: hi: command not found

>podman exec -it ctr_name /bin/bash -c 'hi' 1> 1.txt 2> 2.txt
>cat 1.txt 
/bin/bash: hi: command not found
>cat 2.txt 
```

I've added a testcase for the `--interactive` only case however stdout/stderr isn't captured by PoW in the `-it` case so no test has been added there (this also does not affect the existing behaviour there anyway).