### PR TITLE
fix: wheel includes tests and docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ test = [
 python-on-whales = "python_on_whales.command_line_entrypoint:main"
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "docs"]
+exclude = ["tests*", "docs*"]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Currently the wheels include `tests` and `docs`. (see attached log 1)

This can cause problems with buildsystems like bazel.

Based on the configuration in [pyproject.toml](https://github.com/gabrieldemarmiesse/python-on-whales/blob/99e93d02ab6f3c90b7aa9fda40375bdd9a420a86/pyproject.toml#L31) I'm assuming this is unintended behavior.

This PR excludes them from the build. (see attached log 2)


log 1:
```sh
$ wget https://files.pythonhosted.org/packages/af/5d/7a2773be8ad9e253b07c968849a705aa3b83796
cfd08a5960da976c60716/python_on_whales-0.71.0-py3-none-any.whl
$ unzip -t python_on_whales-0.71.0-py3-none-any.whl | grep -e tests -e docs
    testing: docs/template/docker_client.md   OK
    testing: docs/template/index.md   OK
    testing: docs/template/docker_objects/builders.md   OK
    testing: docs/template/docker_objects/configs.md   OK
    testing: docs/template/docker_objects/containers.md   OK
    testing: docs/template/docker_objects/images.md   OK
    testing: docs/template/docker_objects/networks.md   OK
    testing: docs/template/docker_objects/nodes.md   OK
    testing: docs/template/docker_objects/plugins.md   OK
    testing: docs/template/docker_objects/services.md   OK
    testing: docs/template/docker_objects/tasks.md   OK
    testing: docs/template/docker_objects/volumes.md   OK
    testing: docs/template/sub-commands/buildx.md   OK
    testing: docs/template/sub-commands/compose.md   OK
    testing: docs/template/sub-commands/context.md   OK
    testing: docs/template/user_guide/docker_run.md   OK
    testing: docs/template/user_guide/exceptions.md   OK
    testing: docs/template/user_guide/generic_resources.md   OK
    testing: docs/template/user_guide/running_python_on_whales_inside_a_container.md   OK
    testing: tests/python_on_whales/test_client_config.py   OK
    testing: tests/python_on_whales/test_docker_client.py   OK
    testing: tests/python_on_whales/test_download_binaries.py   OK
    testing: tests/python_on_whales/test_exceptions.py   OK
    testing: tests/python_on_whales/test_utils.py   OK
    testing: tests/python_on_whales/components/test_compose.py   OK
    testing: tests/python_on_whales/components/test_config.py   OK
    testing: tests/python_on_whales/components/test_container.py   OK
    testing: tests/python_on_whales/components/test_context.py   OK
    testing: tests/python_on_whales/components/test_image.py   OK
    testing: tests/python_on_whales/components/test_manifest.py   OK
    testing: tests/python_on_whales/components/test_network.py   OK
    testing: tests/python_on_whales/components/test_node.py   OK
    testing: tests/python_on_whales/components/test_plugin.py   OK
    testing: tests/python_on_whales/components/test_service.py   OK
    testing: tests/python_on_whales/components/test_stack.py   OK
    testing: tests/python_on_whales/components/test_swarm.py   OK
    testing: tests/python_on_whales/components/test_system.py   OK
    testing: tests/python_on_whales/components/test_task.py   OK
    testing: tests/python_on_whales/components/test_volume.py   OK
    testing: tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py   OK
    testing: tests/python_on_whales/components/buildx/imagetools/test_imagetools_cli_wrapper.py   OK
    testing: tests/python_on_whales/components/buildx/imagetools/test_models.py   OK
```

log 2:
```sh
$ python -m build
$ unzip -t dist/python_on_whales-0.71.0-py3-none-any.whl | grep -e tests -e docs
```