### PR TITLE
Drop typing-extensions in recent Python versions

### DIFF
--- a/python_on_whales/components/buildx/imagetools/models.py
+++ b/python_on_whales/components/buildx/imagetools/models.py
@@ -4,6 +4,7 @@ import sys
 from typing import List, Optional
 
 import pydantic
+
 if sys.version_info >= (3, 9):
     from typing import Annotated
 else:

--- a/python_on_whales/components/buildx/imagetools/models.py
+++ b/python_on_whales/components/buildx/imagetools/models.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import sys
 from typing import List, Optional
 
 import pydantic
-from typing_extensions import Annotated
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class ManifestConfig(pydantic.BaseModel):

--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import json
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, overload
-
-from typing_extensions import Literal
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple, Union, overload
 
 import python_on_whales.components.container.cli_wrapper
 from python_on_whales.client_config import DockerCLICaller

--- a/python_on_whales/components/compose/models.py
+++ b/python_on_whales/components/compose/models.py
@@ -1,8 +1,13 @@
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class ServicePlacement(BaseModel):

--- a/python_on_whales/components/config/models.py
+++ b/python_on_whales/components/config/models.py
@@ -1,10 +1,15 @@
+import sys
 from datetime import datetime
 from typing import Any, Dict, Optional
 
 import pydantic
-from typing_extensions import Annotated
 
 from python_on_whales.utils import DockerCamelModel
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class DockerObjectVersion(DockerCamelModel):

--- a/python_on_whales/components/container/models.py
+++ b/python_on_whales/components/container/models.py
@@ -1,11 +1,16 @@
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pydantic
-from typing_extensions import Annotated
 
 from python_on_whales.utils import DockerCamelModel
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class ContainerHealthcheckResult(DockerCamelModel):

--- a/python_on_whales/components/context/models.py
+++ b/python_on_whales/components/context/models.py
@@ -1,9 +1,14 @@
+import sys
 from typing import Dict, Optional
 
 import pydantic
-from typing_extensions import Annotated
 
 from python_on_whales.utils import DockerCamelModel
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class ContextEndpoint(DockerCamelModel):

--- a/python_on_whales/components/node/models.py
+++ b/python_on_whales/components/node/models.py
@@ -1,10 +1,15 @@
+import sys
 from datetime import datetime
 from typing import Dict, List, Optional
 
 from pydantic import Field
-from typing_extensions import Annotated
 
 from python_on_whales.utils import DockerCamelModel
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class NodeVersion(DockerCamelModel):

--- a/python_on_whales/components/service/models.py
+++ b/python_on_whales/components/service/models.py
@@ -1,10 +1,15 @@
+import sys
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import Field
-from typing_extensions import Annotated
 
 from python_on_whales.utils import DockerCamelModel
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class CPUMemoryQuotas(DockerCamelModel):

--- a/python_on_whales/components/system/models.py
+++ b/python_on_whales/components/system/models.py
@@ -1,12 +1,17 @@
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pydantic
-from typing_extensions import Annotated
 
 import python_on_whales.components.node.models
 from python_on_whales.utils import DockerCamelModel
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class DockerEventActor(DockerCamelModel):

--- a/python_on_whales/components/task/models.py
+++ b/python_on_whales/components/task/models.py
@@ -1,10 +1,15 @@
+import sys
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import pydantic
-from typing_extensions import Annotated
 
 from python_on_whales.utils import DockerCamelModel
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class ObjectVersion(DockerCamelModel):

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -8,10 +8,20 @@ from pathlib import Path
 from queue import Queue
 from subprocess import PIPE, Popen
 from threading import Thread
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union, overload
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    overload,
+)
 
 import pydantic
-from typing_extensions import Literal
 
 from python_on_whales.exceptions import (
     DockerException,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pydantic>=1.9,<3,!=2.0.*
 requests
 tqdm
 typer>=0.4.1
-typing_extensions
+typing_extensions; python_version < "3.11"


### PR DESCRIPTION
It would be best to drop typing-extensions as a dependency when it's no longer needed. This removes the dependency on Python 3.11+.