### PR TITLE
Fix test_save_load() testcase to handle the case an image has multiple tags

### DIFF
--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -100,7 +100,7 @@ def test_save_iterator_bytes_and_load_from_iterator_list_of_images(
     ]
     iterator = ctr_client.image.save(image_names)
     # Cannot remove the image here because the save may still be in progress!
-    assert set(ctr_client.image.load(iterator)) == image_tags
+    assert set(ctr_client.image.load(iterator)) == set(image_tags)
 
 
 @pytest.mark.parametrize(

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -78,10 +78,8 @@ def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
     image = ctr_client.image.pull(image_name, quiet=True)
     image_tag = [tag for tag in image.repo_tags if tag.endswith(image_name)][0]
     iterator = ctr_client.image.save(image_name)
-    ctr_client.image.remove(image_name, force=True)
-    assert not ctr_client.image.exists(image_name)
+    # Cannot remove the image here because the save may still be in progress!
     assert ctr_client.image.load(iterator) == [image_tag]
-    assert ctr_client.image.exists(image_name)
 
 
 @pytest.mark.parametrize(
@@ -101,10 +99,8 @@ def test_save_iterator_bytes_and_load_from_iterator_list_of_images(
         if any(tag.endswith(n) for n in image_names)
     ]
     iterator = ctr_client.image.save(image_names)
-    ctr_client.image.remove(image_names, force=True)
-    assert not ctr_client.image.exists(image_names)
+    # Cannot remove the image here because the save may still be in progress!
     assert set(ctr_client.image.load(iterator)) == image_tags
-    assert ctr_client.image.exists(image_names)
 
 
 @pytest.mark.parametrize(

--- a/tests/python_on_whales/components/test_image.py
+++ b/tests/python_on_whales/components/test_image.py
@@ -40,12 +40,12 @@ def test_save_load(ctr_client: DockerClient, tmp_path: Path):
     image_name = "busybox:1"
     image = ctr_client.image.pull(image_name, quiet=True)
     image_tag = [tag for tag in image.repo_tags if tag.endswith(image_name)][0]
-    ctr_client.image.save(image_tag, output=tar_file)
-    image.remove(force=True)
-    assert not ctr_client.image.exists(image_tag)
+    ctr_client.image.save(image_name, output=tar_file)
+    ctr_client.image.remove(image_name, force=True)
+    assert not ctr_client.image.exists(image_name)
     loaded_tags = ctr_client.image.load(input=tar_file)
     assert loaded_tags == [image_tag]
-    assert ctr_client.image.exists(image_tag)
+    assert ctr_client.image.exists(image_name)
 
 
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
@@ -62,22 +62,26 @@ def test_save_iterator_bytes(ctr_client: DockerClient):
 
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
-    image = ctr_client.image.pull("busybox:1", quiet=True)
-    image_tags = image.repo_tags
-    iterator = ctr_client.image.save("busybox:1")
+    image_name = "busybox:1"
+    image = ctr_client.image.pull(image_name, quiet=True)
+    image_tag = [tag for tag in image.repo_tags if tag.endswith(image_name)][0]
+    iterator = ctr_client.image.save(image_name)
     my_tar_as_bytes = b"".join(iterator)
     image.remove(force=True)
-    assert ctr_client.image.load(my_tar_as_bytes) == image_tags
-    ctr_client.image.inspect("busybox:1")
+    assert ctr_client.image.load(my_tar_as_bytes) == [image_tag]
+    assert ctr_client.image.exists(image_name)
 
 
 @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_save_iterator_bytes_and_load_from_iterator(ctr_client: DockerClient):
-    image = ctr_client.image.pull("busybox:1", quiet=True)
-    image_tags = image.repo_tags
-    iterator = ctr_client.image.save("busybox:1")
-    assert ctr_client.image.load(iterator) == image_tags
-    ctr_client.image.inspect("busybox:1")
+    image_name = "busybox:1"
+    image = ctr_client.image.pull(image_name, quiet=True)
+    image_tag = [tag for tag in image.repo_tags if tag.endswith(image_name)][0]
+    iterator = ctr_client.image.save(image_name)
+    ctr_client.image.remove(image_name, force=True)
+    assert not ctr_client.image.exists(image_name)
+    assert ctr_client.image.load(iterator) == [image_tag]
+    assert ctr_client.image.exists(image_name)
 
 
 @pytest.mark.parametrize(
@@ -90,10 +94,17 @@ def test_save_iterator_bytes_and_load_from_iterator_list_of_images(
 ):
     image_names = ["busybox:1", "hello-world:latest"]
     images = ctr_client.image.pull(image_names, quiet=True)
-    image_tags = {tag for image in images for tag in image.repo_tags}
+    image_tags = [
+        tag
+        for image in images
+        for tag in image.repo_tags
+        if any(tag.endswith(n) for n in image_names)
+    ]
     iterator = ctr_client.image.save(image_names)
+    ctr_client.image.remove(image_names, force=True)
+    assert not ctr_client.image.exists(image_names)
     assert set(ctr_client.image.load(iterator)) == image_tags
-    ctr_client.image.inspect(image_names)
+    assert ctr_client.image.exists(image_names)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If the user pulls the `busybox:1` image under another tag/name then image save/load tests fail because `ctr_client.image.pull("busybox:1", quiet=True).repo_tags` returns all tags, while only a single tag is loaded.

There's also a subtle difference between `ctr_client.image.remove(image_name, force=True)` and `image.remove(force=True)` - the former runs `docker image rm -f image_name`, the latter runs `docker image rm -f image_id` removing all tags for that image ID. The tests should only remove the tag we're working with (ideally they'd use a test-specific tag that won't be in use on the system!).

Also note there's a questionable behaviour where getting an image save iterator doesn't wait for the save to complete, meaning a subsequent removal of the image can cause failures, although maybe this is implicit from the fact you get an iterator...

```
___________________________________________________ test_save_iterator_bytes_and_load[docker] ___________________________________________________

ctr_client = <python_on_whales.docker_client.DockerClient object at 0x7f7cc7fd3310>

    @pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
    def test_save_iterator_bytes_and_load(ctr_client: DockerClient):
        image = ctr_client.image.pull("busybox:1", quiet=True)
        image_tags = image.repo_tags
        iterator = ctr_client.image.save("busybox:1")
        my_tar_as_bytes = b"".join(iterator)
        image.remove(force=True)
>       assert ctr_client.image.load(my_tar_as_bytes) == image_tags
E       AssertionError: assert ['busybox:1'] == ['busybox:1', 'busybox:latest']
E         Right contains one more item: 'busybox:latest'
E         Full diff:
E         - ['busybox:1', 'busybox:latest']
E         + ['busybox:1']

tests/python_on_whales/components/test_image.py:70: AssertionError
```