### PR TITLE
Make the test_cpus() testcase non-strict xfail for podman

### DIFF
--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -295,7 +295,8 @@ def test_remove_on_exit(ctr_client: DockerClient):
         pytest.param(
             "podman",
             marks=pytest.mark.xfail(
-                reason="Cgroup control not available with rootless podman on cgroups v1"
+                reason="Cgroup control not available with rootless podman on cgroups v1",
+                strict=False,
             ),
         ),
     ],


### PR DESCRIPTION
It works on cgroups v2 or rootful:
```
$python -m pytest tests/python_on_whales/components/test_container.py -k cpus -v
============================================================== test session starts ==============================================================
platform linux -- Python 3.8.19, pytest-7.4.4, pluggy-1.5.0 -- /home/legaul/repos/python-on-whales/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/legaul/repos/python-on-whales
configfile: pyproject.toml
plugins: mock-3.14.0
collected 223 items / 221 deselected / 2 selected

tests/python_on_whales/components/test_container.py::test_cpus[docker] PASSED                                                             [ 50%]
tests/python_on_whales/components/test_container.py::test_cpus[podman] XPASS (Cgroup control not available with rootless podman on cg...) [100%]

================================================= 1 passed, 221 deselected, 1 xpassed in 2.31s ==================================================
```