### PR TITLE
Add bootstrap cli flag for create/inspect

### DIFF
--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -507,7 +507,7 @@ class BuildxCLI(DockerCLICaller):
     def inspect(
         self,
         x: Optional[str] = None,
-        bootstrap: Optional[bool] = False,
+        bootstrap: bool = False,
     ) -> Builder:
         """Returns a builder instance from the name.
 

--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -454,6 +454,7 @@ class BuildxCLI(DockerCLICaller):
     def create(
         self,
         context_or_endpoint: Optional[str] = None,
+        bootstrap: bool = False,
         buildkitd_flags: Optional[str] = None,
         config: Optional[ValidPath] = None,
         platforms: Optional[List[str]] = None,
@@ -466,6 +467,7 @@ class BuildxCLI(DockerCLICaller):
 
         Parameters:
             context_or_endpoint:
+            bootstrap: Boot builder after creation
             buildkitd_flags: Flags for buildkitd daemon
             config: BuildKit config file
             platforms: Comma-separated list of platforms of the form OS/architecture/variant. Ex:
@@ -481,6 +483,7 @@ class BuildxCLI(DockerCLICaller):
         """
         full_cmd = self.docker_cmd + ["buildx", "create"]
 
+        full_cmd.add_flag("--bootstrap", bootstrap)
         full_cmd.add_simple_arg("--buildkitd-flags", buildkitd_flags)
         full_cmd.add_simple_arg("--config", config)
         if platforms is not None:
@@ -501,16 +504,27 @@ class BuildxCLI(DockerCLICaller):
         """Not yet implemented"""
         raise NotImplementedError
 
-    def inspect(self, x: Optional[str] = None) -> Builder:
+    def inspect(
+        self,
+        x: Optional[str] = None,
+        bootstrap: Optional[bool] = False,
+    ) -> Builder:
         """Returns a builder instance from the name.
 
         Parameters:
             x: If `None` (the default), returns the current builder. If a string is provided,
                 the builder that has this name is returned.
+            bootstrap: If set to True, ensure builder has booted before inspecting.
 
         # Returns
             A `python_on_whales.Builder` object.
         """
+        if bootstrap:
+            full_cmd = self.docker_cmd + ["buildx", "inspect"]
+            if x is not None:
+                full_cmd.append(x)
+            full_cmd.add_flag("--bootstrap", bootstrap)
+            run(full_cmd)
         return Builder(self.client_config, x, is_immutable_id=False)
 
     def list(self) -> List[Builder]:

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -366,6 +366,14 @@ def test_inspect():
         assert docker.buildx.inspect() == my_builder
 
 
+def test_buildx_inspect_bootstrap():
+    my_builder = docker.buildx.create()
+    with my_builder:
+        docker.buildx.inspect(my_builder.name, bootstrap=True)
+        assert my_builder.status == 'running'
+        assert my_builder.platforms #Must contain at least the host native platform
+
+
 def test_builder_name():
     my_builder = docker.buildx.create(name="some_builder")
     with my_builder:
@@ -473,6 +481,13 @@ def test_buildx_create_remove():
     builder = docker.buildx.create()
 
     docker.buildx.remove(builder)
+
+
+def test_buildx_create_bootstrap():
+    my_builder = docker.buildx.create(bootstrap=True)
+    with my_builder:
+        assert my_builder.status == 'running'
+        assert my_builder.platforms #Must contain at least the host native platform
 
 
 def test_buildx_create_remove_with_platforms():

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -370,7 +370,7 @@ def test_buildx_inspect_bootstrap():
     my_builder = docker.buildx.create()
     with my_builder:
         docker.buildx.inspect(my_builder.name, bootstrap=True)
-        assert my_builder.status == 'running'
+        assert my_builder.status == "running"
         # Must contain at least the host native platform
         assert my_builder.platforms
 
@@ -487,7 +487,7 @@ def test_buildx_create_remove():
 def test_buildx_create_bootstrap():
     my_builder = docker.buildx.create(bootstrap=True)
     with my_builder:
-        assert my_builder.status == 'running'
+        assert my_builder.status == "running"
         # Must contain at least the host native platform
         assert my_builder.platforms
 

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -371,7 +371,7 @@ def test_buildx_inspect_bootstrap():
     with my_builder:
         docker.buildx.inspect(my_builder.name, bootstrap=True)
         assert my_builder.status == 'running'
-        #Must contain at least the host native platform
+        # Must contain at least the host native platform
         assert my_builder.platforms
 
 
@@ -488,7 +488,7 @@ def test_buildx_create_bootstrap():
     my_builder = docker.buildx.create(bootstrap=True)
     with my_builder:
         assert my_builder.status == 'running'
-        #Must contain at least the host native platform
+        # Must contain at least the host native platform
         assert my_builder.platforms
 
 

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -371,7 +371,8 @@ def test_buildx_inspect_bootstrap():
     with my_builder:
         docker.buildx.inspect(my_builder.name, bootstrap=True)
         assert my_builder.status == 'running'
-        assert my_builder.platforms #Must contain at least the host native platform
+        #Must contain at least the host native platform
+        assert my_builder.platforms
 
 
 def test_builder_name():
@@ -487,7 +488,8 @@ def test_buildx_create_bootstrap():
     my_builder = docker.buildx.create(bootstrap=True)
     with my_builder:
         assert my_builder.status == 'running'
-        assert my_builder.platforms #Must contain at least the host native platform
+        #Must contain at least the host native platform
+        assert my_builder.platforms
 
 
 def test_buildx_create_remove_with_platforms():


### PR DESCRIPTION
Hello,
The purpose of this PR is to add the hability to use the --bootstrap optional flag for the following commands :
`$ docker buildx create [OPTIONS] [CONTEXT|ENDPOINT]`
`$ docker buildx inspect [NAME]`