### PR TITLE
Replace unrecognised unicode characters rather than raising an exception

### DIFF
--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -237,10 +237,10 @@ def run(
         return post_process_stream(completed_process.stdout)
 
 
-def post_process_stream(stream: Optional[bytes]):
+def post_process_stream(stream: Optional[bytes]) -> str:
     if stream is None:
         return ""
-    stream = stream.decode()
+    stream = stream.decode(errors="replace")
     if len(stream) != 0 and stream[-1] == "\n":
         stream = stream[:-1]
     return stream


### PR DESCRIPTION
Fixes https://github.com/gabrieldemarmiesse/python-on-whales/issues/606

Note that this still isn't ideal - if someone has a container expected to have output in an encoding other than unicode then special characters will all be replaced... It might be good to support the user passing `encoding` and `errors` through (much like [`subprocess.run()`](https://docs.python.org/3/library/subprocess.html#subprocess.run)), but for now this seems like an improvement at least.