### PR TITLE
Add support for 'podman container init'

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -320,7 +320,14 @@ class Container(ReloadableObjectFromJson):
         """
         return ContainerCLI(self.client_config).export(self, output)
 
-    def kill(self, signal: Optional[Union[int, str]] = None):
+    def init(self) -> None:
+        """Initialize this container.
+
+        See the [`docker.container.init`](../sub-commands/container.md#init) command.
+        """
+        return ContainerCLI(self.client_config).init(self)
+
+    def kill(self, signal: Optional[Union[int, str]] = None) -> None:
         """Kill this container
 
         See the [`docker.container.kill`](../sub-commands/container.md#kill) command for
@@ -1001,6 +1008,32 @@ class ContainerCLI(DockerCLICaller):
             raise NotImplementedError
         else:
             run(full_cmd)
+
+    def init(self, containers: Union[ValidContainer, List[ValidContainer]]) -> None:
+        """Initialize one or more containers.
+
+        Note that this is only supported by podman.
+
+        Alias: `docker.init(...)`
+
+        Parameters:
+            containers: One or more containers to kill
+            output: The path of the output tar archive. Returning a generator of bytes
+                is not yet implemented.
+
+        # Raises
+            `python_on_whales.exceptions.NoSuchContainer` if any of the
+            containers do not exist.
+        """
+        containers = to_list(containers)
+        if len(containers) == 0:
+            # nothing to do
+            return
+
+        full_cmd = self.docker_cmd + ["container", "init"]
+        full_cmd += containers
+
+        run(full_cmd)
 
     @overload
     def inspect(self, x: ValidContainer, /) -> Container:

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -261,6 +261,16 @@ def test_create_start_with_timezone(podman_client: DockerClient):
         assert output == "GMT"
 
 
+def test_init_container(podman_client: DockerClient):
+    with podman_client.container.create("ubuntu", ["sleep", "infinity"]) as container:
+        assert not container.state.pid
+        assert container.state.status.lower() == "created"
+        container.init()
+        container.reload()
+        assert container.state.pid
+        assert container.state.status.lower() == "initialized"
+
+
 @pytest.mark.parametrize(
     "ctr_client",
     ["docker", pytest.param("podman", marks=pytest.mark.xfail)],
@@ -915,6 +925,11 @@ def test_functions_nosuchcontainer(ctr_client: DockerClient, method: str):
         pytest.xfail()
     with pytest.raises(NoSuchContainer):
         getattr(ctr_client.container, method)("DOODODGOIHURHURI")
+
+
+def test_init_nosuchcontainer(podman_client: DockerClient):
+    with pytest.raises(NoSuchContainer):
+        podman_client.container.init("DOODODGOIHURHURI")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I haven't added the `DockerClient.init()` alias although `podman init` is supported, because it's not supported by docker... Should I add it?