### PR TITLE
Fix handling of 'podman pod create --share=...'

### DIFF
--- a/python_on_whales/components/pod/cli_wrapper.py
+++ b/python_on_whales/components/pod/cli_wrapper.py
@@ -295,7 +295,7 @@ class PodCLI(DockerCLICaller):
         replace: bool = False,
         restart: Optional[str] = None,
         security_options: List[str] = [],
-        share: List[str] = [],
+        share: Optional[List[str]] = None,
         shm_size: Optional[Union[int, str]] = None,
         subgidname: Optional[str] = None,
         subuidname: Optional[str] = None,
@@ -441,7 +441,8 @@ class PodCLI(DockerCLICaller):
         full_cmd.add_flag("--replace", replace)
         full_cmd.add_simple_arg("--restart", restart)
         full_cmd.add_args_iterable_or_single("--security-opt", security_options)
-        full_cmd.add_args_iterable_or_single("--share", share)
+        if share is not None:
+            full_cmd.add_simple_arg("--share", ",".join(share))
         full_cmd.add_simple_arg("--shm-size", shm_size)
         full_cmd.add_simple_arg("--subgidname", subgidname)
         full_cmd.add_simple_arg("--subuidname", subuidname)

--- a/tests/python_on_whales/components/test_pod.py
+++ b/tests/python_on_whales/components/test_pod.py
@@ -185,14 +185,16 @@ def test_create_replace_arg(podman_client: DockerClient):
 
 def test_create_share_arg(podman_client: DockerClient):
     pod_name = random_name()
-    with podman_client.pod.create(pod_name, share=[]) as pod:
+    with podman_client.pod.create(pod_name, share=[], infra=True) as pod:
         pod.start()  # start the infra container
+        assert not pod.shared_namespaces
         output = podman_client.container.run(
             "ubuntu", ["readlink", "/proc/self"], pod=pod
         )
         assert output == "1"
     with podman_client.pod.create(pod_name, share=["pid"]) as pod:
         pod.start()  # start the infra container (PID 1)
+        assert pod.shared_namespaces == ["pid"]
         output = podman_client.container.run(
             "ubuntu", ["readlink", "/proc/self"], pod=pod
         )


### PR DESCRIPTION
Previously treated `Pod.create(share=[])` the same as not passing the `share` arg (not passing it to podman), but the podman default is to share `uts`, `ipc` and `net` namespaces. This means there's no way to specify that *no* namespaces should be shared.

In addition, podman expects this list of namespaces to be passed as a single comma-separated arg, e.g. `--share uts,ipc`, not in the form `--share uts --share ipc` (only the last is taken in this case). This means there's another bug where the use of the internal `Command.add_args_iterable()` helper method meant only one shared namespace could be specified.

It seems possible there could be other related bugs to do with the format of lists on the CLI...