### PR TITLE
add auto/light/dark mode for docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,6 +7,25 @@ site_description: 'Python on whales docs'
 
 theme:
   name: material
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default 
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to system preference
+
 
 markdown_extensions:
 - pymdownx.snippets:


### PR DESCRIPTION
just like the example in the documentation:
https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode