### PR TITLE
Fix "Render docs" CI job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,8 +18,9 @@ jobs:
       - name: prepare
         run: |
           ./scripts/ci-podman-update.sh
+          pip install -U pip wheel
           pip install -r ./requirements.txt -r docs/requirements.txt -e .
-          python docs/autogen.py
+          ./docs/autogen.py
           cp -r docs/generated_sources ./generated_sources
           cp docs/mkdocs.yml ./
       - name: Render

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,7 @@ jobs:
           python-version: 3.8
       - name: prepare
         run: |
+          ./scripts/ci-podman-update.sh
           pip install -r ./requirements.txt -r docs/requirements.txt -e .
           python docs/autogen.py
           cp -r docs/generated_sources ./generated_sources

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import shutil
 from pathlib import Path

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,6 @@ mkdocs==1.6.1
 mkdocstrings==0.25.2
 mkdocs-autorefs==1.1.0
 mkdocs-get-deps==0.2.0
+mkdocs-material==9.5.34
 mkdocstrings==0.25.2
 pymdown-extensions==10.9

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,8 @@
-mkdocstrings==0.25.1
-mkdocstrings-python==1.10.5
-mkdocs-autorefs==0.4.1
-mkdocs-material==9.1.14
-pymdown-extensions==10.0.1
-markdown==3.3.7
-black==24.4.2
+markdown==3.7
+markupsafe==2.1.5
+mkdocs==1.6.1
+mkdocstrings==0.25.2
+mkdocs-autorefs==1.1.0
+mkdocs-get-deps==0.2.0
+mkdocstrings==0.25.2
+pymdown-extensions==10.9

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,11 @@
+astunparse==1.6.3
+griffe==1.2.0
 markdown==3.7
 markupsafe==2.1.5
 mkdocs==1.6.1
-mkdocstrings==0.25.2
 mkdocs-autorefs==1.1.0
 mkdocs-get-deps==0.2.0
 mkdocs-material==9.5.34
 mkdocstrings==0.25.2
+mkdocstrings-python==1.10.9
 pymdown-extensions==10.9


### PR DESCRIPTION
Hopefully fixing two issues that have started being hit in the "Render docs" CI job:
* `podman pod create` failing with "initializing source docker://k8s.gcr.io/pause:3.5: Requesting bear token: invalid status code from registry 404 (Not Found)", reported at https://github.com/gabrieldemarmiesse/python-on-whales/pull/625#issuecomment-2309580047 and seen in other PRs too.
  * Fixed by updating podman in the CI, since doc generation involves running podman commands.
* `ModuleNotFoundError: No module named 'griffe.collections'` reported at https://github.com/gabrieldemarmiesse/python-on-whales/pull/625#issuecomment-2322094393 and seen in other PRs too.
  * Fixed by updating doc package dependencies and pinning a couple more indirect dependencies (I think the lack of pinning `griffe` while pinning to an older version of `mkdocstrings-python` was the problem...).