### PR TITLE
Fix the CI setup and podman testcase

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,7 +3,7 @@ name: Run tests
 on:
   push:
     branches:
-      - "*"
+      - master
   pull_request: {}
 
 jobs:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,7 +3,7 @@ name: Run tests
 on:
   push:
     branches:
-      - master
+      - "*"
   pull_request: {}
 
 jobs:

--- a/scripts/add-local-docker-registry.sh
+++ b/scripts/add-local-docker-registry.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-cat /etc/docker/daemon.json
+cat /etc/docker/daemon.json || true
 echo '{"insecure-registries" : [ "localhost:5000" ]}' | sudo tee /etc/docker/daemon.json
 sudo service docker restart
 sleep 2

--- a/scripts/ci-podman-update.sh
+++ b/scripts/ci-podman-update.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
 
-ubuntu_version='22.04'
-key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
-sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
-
-echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
-curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
 sudo apt update -y
 sudo apt install -y podman

--- a/tests/python_on_whales/components/test_volume.py
+++ b/tests/python_on_whales/components/test_volume.py
@@ -52,19 +52,7 @@ def test_multiple_volumes(ctr_client: DockerClient):
         assert v not in ctr_client.volume.list()
 
 
-@pytest.mark.parametrize(
-    "ctr_client",
-    [
-        "docker",
-        pytest.param(
-            "podman",
-            marks=pytest.mark.xfail(
-                reason="'podman volume create' does not support size option"
-            ),
-        ),
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
 def test_volume_drivers(ctr_client: DockerClient):
     some_volume = ctr_client.volume.create(
         driver="local",


### PR DESCRIPTION
Fixes https://github.com/gabrieldemarmiesse/python-on-whales/issues/636

- Podman is now available in the default Ubuntu apt repos
- Docker now doesn't come with the daemon config file (not a problem)
- Newer version of podman has support for something that was previously an xfail testcase