### PR TITLE
Display an error message if using the `python-on-whales` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dev = ["ruff==0.5.6"]
 "Documentation" = "https://gabrieldemarmiesse.github.io/python-on-whales/"
 "Bug Tracker" = "https://github.com/gabrieldemarmiesse/python-on-whales/issues"
 
+[project.scripts]
+python-on-whales = "python_on_whales.command_line_entrypoint:main"
+
 [tool.setuptools.packages.find]
 exclude = ["tests*", "docs*"]
 

--- a/python_on_whales/command_line_entrypoint.py
+++ b/python_on_whales/command_line_entrypoint.py
@@ -1,0 +1,8 @@
+def main():
+    print(
+        "The python-on-whales command line interface has been removed "
+        "in python-on-whales v0.74.0. If you were using it to download the docker CLI, "
+        "you should instead do it manually. "
+        "Take a look at https://gabrieldemarmiesse.github.io/python-on-whales/docker_client/ "
+        "which has instructions to download the Docker client."
+    )


### PR DESCRIPTION
Before:

```
$ python-on-whales download-cli
zsh: command not found: python-on-whales
```

After:

```
$ python-on-whales download-cli
The python-on-whales command line interface has been removed in python-on-whales v0.74.0. If you were using it to download the docker CLI, you should instead do it manually. Take a look at https://gabrieldemarmiesse.github.io/python-on-whales/docker_client/ which has instructions to download the Docker client.
```