### PR TITLE
Set `defer_build=True` pydantic config, improving import time significantly

### DIFF
--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -97,6 +97,7 @@ class DockerCamelModel(pydantic.BaseModel):
         model_config = pydantic.ConfigDict(
             populate_by_name=True,
             alias_generator=to_docker_camel,
+            defer_build=True,
         )
     else:
 


### PR DESCRIPTION
Partially addresses https://github.com/gabrieldemarmiesse/python-on-whales/issues/552. This config option is suggested in https://github.com/pydantic/pydantic/discussions/6748.

Before:
```
$time python -c "import python_on_whales"

real    0m0.405s
user    0m0.401s
sys     0m0.023s
```

After:
```
$time python -c "import python_on_whales"

real    0m0.206s
user    0m0.206s
sys     0m0.011s
```