### PR TITLE
Support bake remote definitions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,6 +22,10 @@ jobs:
           cp docs/mkdocs.yml ./
       - name: Render
         run: uv run mkdocs build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Docs
+          path: site
 
   build-linux-lint:
     runs-on: ubuntu-24.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,16 @@ of the file `docs/docs_utils.py` which is responsible for generating the part of
 http://localhost:8000
 
 
+### Use CI-generated docs
+
+The GitHub workflows automatically generate the docs and save them as artifacts. These can be accessed from the Artifacts section of the worfklow view (as [documented here](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/downloading-workflow-artifacts)).
+
+To view them:
+
+1. Download the artifact labeled `Docs`.
+1. Extract the contents of the resulting `Docs.zip` file.
+1. Open the `index.html` file in a browser.
+
 ## Running the tests
 
 Same as before, using `uv` means that you don't need to install anything. Just run

--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -126,6 +126,7 @@ class BuildxCLI(DockerCLICaller):
         set: Dict[str, str] = {},
         variables: Dict[str, str] = {},
         stream_logs: bool = False,
+        remote_definition: Union[str, None] = None,
     ) -> Union[Dict[str, Dict[str, Dict[str, Any]]], Iterator[str]]:
         """Bake is similar to make, it allows you to build things declared in a file.
 
@@ -148,6 +149,7 @@ class BuildxCLI(DockerCLICaller):
             set: A list of overrides in the form `"targetpattern.key=value"`.
             variables: A dict containing the values of the variables defined in the
                 hcl file. See <https://github.com/docker/buildx#hcl-variables-and-functions>
+            remote_definition: Remote context in which to find bake files
 
         # Returns
             The configuration used for the bake (files merged + override with
@@ -197,6 +199,8 @@ class BuildxCLI(DockerCLICaller):
         for file in to_list(files):
             full_cmd.add_simple_arg("--file", file)
         full_cmd.add_args_iterable_or_single("--set", format_mapping_for_cli(set))
+        if remote_definition is not None:
+            full_cmd.append(remote_definition)
         targets = to_list(targets)
         env = dict(variables)
         if print:

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -656,6 +656,55 @@ def test_bake_with_variables_2(only_print, monkeypatch):
 
 @pytest.mark.usefixtures("with_docker_driver")
 @pytest.mark.usefixtures("change_cwd")
+@pytest.mark.parametrize("only_print", [True, False])
+def test_bake_with_remote_definition(only_print):
+    config = docker.buildx.bake(
+        print=only_print,
+        remote_definition="https://github.com/gabrieldemarmiesse/python-on-whales.git#v0.74.0:tests/python_on_whales/components/bake_tests",
+    )
+    assert config == {
+        "group": {"default": {"targets": ["my_out1", "my_out2"]}},
+        "target": {
+            "my_out1": {
+                "context": "https://github.com/gabrieldemarmiesse/python-on-whales.git#v0.74.0:tests/python_on_whales/components/bake_tests",
+                "dockerfile": "Dockerfile",
+                "tags": ["pretty_image1:1.0.0"],
+                "target": "out1",
+            },
+            "my_out2": {
+                "context": "https://github.com/gabrieldemarmiesse/python-on-whales.git#v0.74.0:tests/python_on_whales/components/bake_tests",
+                "dockerfile": "Dockerfile",
+                "tags": ["pretty_image2:1.0.0"],
+                "target": "out2",
+            },
+        },
+    }
+
+
+@pytest.mark.usefixtures("with_docker_driver")
+@pytest.mark.usefixtures("change_cwd")
+@pytest.mark.parametrize("only_print", [True, False])
+def test_bake_with_remote_definition_and_target(only_print):
+    config = docker.buildx.bake(
+        print=only_print,
+        targets=["my_out2"],
+        remote_definition="https://github.com/gabrieldemarmiesse/python-on-whales.git#v0.74.0:tests/python_on_whales/components/bake_tests",
+    )
+    assert config == {
+        "group": {"default": {"targets": ["my_out2"]}},
+        "target": {
+            "my_out2": {
+                "context": "https://github.com/gabrieldemarmiesse/python-on-whales.git#v0.74.0:tests/python_on_whales/components/bake_tests",
+                "dockerfile": "Dockerfile",
+                "tags": ["pretty_image2:1.0.0"],
+                "target": "out2",
+            },
+        },
+    }
+
+
+@pytest.mark.usefixtures("with_docker_driver")
+@pytest.mark.usefixtures("change_cwd")
 def test_bake_stream_logs(monkeypatch):
     monkeypatch.setenv("IMAGE_NAME_1", "dodo")
     output = docker.buildx.bake(


### PR DESCRIPTION
Docker buildx bake supports [remote Bake file definitions](https://docs.docker.com/build/bake/remote-definition/#combine-local-and-remote-bake-definitions), but this functionality seems to be missing from the [existing API](https://gabrieldemarmiesse.github.io/python-on-whales/sub-commands/buildx/#python_on_whales.components.buildx.cli_wrapper.BuildxCLI.bake). This change intends to add support for this.

I was lazy about rendering the docs, so also threw in a change to save the rendered files from the CI pipeline as an artifact -- not sure if this would have too much impact on GitHub storage, but figured I'd propose the change.

A couple notes on the implementation:
1. The arg name I selected is "`context`" -- "`definition`" or "`target`" _might_ align better to [upstream docs](https://docs.docker.com/reference/cli/docker/buildx/bake/), though neither is clearly specified in docs and all are overloaded 😬 Very happy to change to a better name if there is one!
1. The `context` arg is directly `append`ed to the `full_cmd`, meaning the content of the arg could technically be _any_ valid bake CLI arg. Validation could prevent this, but didn't seem too important.
1. In the test, I locked the remote ref to the `v0.74.0` tag. This seems slightly awkward, but should at least be safe since its immutable.

Please let me know if I'm missing anything, or if anything needs to be changed!