### PR TITLE
Work around setuptools license file metadata issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ license = { file = "LICENSE" }
 requires-python = ">=3.8, <4"
 dynamic = ["dependencies"]
 
+# Temporary workaround for https://github.com/astral-sh/uv/issues/9513, https://github.com/pypa/setuptools/issues/4759
+[tool.setuptools]
+license-files = []
+
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 


### PR DESCRIPTION
The latest 0.75.0 release [failed to publish to PyPi](https://github.com/gabrieldemarmiesse/python-on-whales/actions/runs/12688518269/job/35365228093). This appears to be a [known behavior of setuptools](https://github.com/pypa/setuptools/issues/4759)/[uv](https://github.com/astral-sh/uv/issues/9513) due to a change to supported metadata.

This change implements a [suggested workaround](https://github.com/astral-sh/uv/issues/9513#issuecomment-2519527822), and [worked for me when testing](https://github.com/rcwbr/python-on-whales/actions/runs/12713875259/job/35442753576).

It appeared to keep the correct license metadata on PyPi, since this field seems to be an optional addition to the `project.license.file` field.

Happy to implement any feedback, please lmk!