### PR TITLE
Add support for multi-nodes on builders

### DIFF
--- a/docs/docs_utils.py
+++ b/docs/docs_utils.py
@@ -206,6 +206,16 @@ def generate_code_demo_builders() -> str:
         to_evaluate = [
             "builder.name",
             "builder.driver",
+            "builder.last_activity",
+            "builder.dynamic",
+            "builder.nodes[0].name",
+            "builder.nodes[0].endpoint",
+            "builder.nodes[0].flags",
+            "builder.nodes[0].status",
+            "builder.nodes[0].version",
+            "builder.nodes[0].ids",
+            "builder.nodes[0].platforms",
+            "builder.nodes[0].labels",
         ]
 
         for i, attribute_access in enumerate(to_evaluate):

--- a/python_on_whales/client_config.py
+++ b/python_on_whales/client_config.py
@@ -206,7 +206,6 @@ class ReloadableObject(DockerCLICaller):
         )
 
     def reload(self):
-        print("fetching and parsing inspect result", self._immutable_id)
         self._set_inspect_result(
             self._fetch_and_parse_inspect_result(self._immutable_id)
         )

--- a/python_on_whales/components/buildx/models.py
+++ b/python_on_whales/components/buildx/models.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime as dt
 from typing import Dict, List, Optional
-from uuid import UUID
 
 from pydantic import Field
 from typing_extensions import Annotated
@@ -16,7 +15,7 @@ class BuilderNode(DockerCamelModel):
     flags: Optional[List[str]] = None
     status: Optional[str] = None
     version: Optional[str] = None
-    ids: Annotated[Optional[List[UUID]], Field(alias="IDs")] = None
+    ids: Annotated[Optional[List[str]], Field(alias="IDs")] = None
     platforms: Optional[List[str]] = None
     labels: Optional[Dict[str, str]] = None
 

--- a/python_on_whales/components/buildx/models.py
+++ b/python_on_whales/components/buildx/models.py
@@ -1,30 +1,29 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import List
+import datetime as dt
+from typing import Dict, List, Optional
+from uuid import UUID
+
+from pydantic import Field
+from typing_extensions import Annotated
+
+from python_on_whales.utils import DockerCamelModel
 
 
-@dataclass
-class BuilderInspectResult:
-    name: str
-    driver: str
-    status: str
-    platforms: List[str] = field(default_factory=lambda: [])
+class BuilderNode(DockerCamelModel):
+    name: Optional[str] = None
+    endpoint: Optional[str] = None
+    flags: Optional[List[str]] = None
+    status: Optional[str] = None
+    version: Optional[str] = None
+    ids: Annotated[Optional[List[UUID]], Field(alias="IDs")] = None
+    platforms: Optional[List[str]] = None
+    labels: Optional[Dict[str, str]] = None
 
-    @classmethod
-    def from_str(cls, string: str) -> BuilderInspectResult:
-        string = string.strip()
-        result_dict = {}
-        for line in string.splitlines():
-            if line.startswith("Name:") and "name" not in result_dict:
-                result_dict["name"] = line.split(":")[1].strip()
-            if line.startswith("Driver:"):
-                result_dict["driver"] = line.split(":")[1].strip()
-            if line.startswith("Status:"):
-                result_dict["status"] = line.split(":")[1].strip()
-            if line.startswith("Platforms:"):
-                platforms = line.split(":")[1].strip()
-                if platforms:
-                    result_dict["platforms"] = platforms.split(", ")
 
-        return cls(**result_dict)
+class BuilderInspectResult(DockerCamelModel):
+    name: Optional[str] = None
+    driver: Optional[str] = None
+    last_activity: Optional[dt.datetime] = None
+    dynamic: Optional[bool] = None
+    nodes: Optional[List[BuilderNode]] = None

--- a/scripts/download-docker-plugins.sh
+++ b/scripts/download-docker-plugins.sh
@@ -5,5 +5,5 @@ set -e
 mkdir -p ~/.docker/cli-plugins/
 wget -q https://github.com/docker/compose/releases/download/v2.26.0/docker-compose-linux-x86_64 -O ~/.docker/cli-plugins/docker-compose
 chmod +x ~/.docker/cli-plugins/docker-compose
-wget -q https://github.com/docker/buildx/releases/download/v0.10.0/buildx-v0.10.0.linux-amd64 -O ~/.docker/cli-plugins/docker-buildx
+wget -q https://github.com/docker/buildx/releases/download/v0.13.0/buildx-v0.13.0.linux-amd64 -O ~/.docker/cli-plugins/docker-buildx
 chmod +x ~/.docker/cli-plugins/docker-buildx

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -369,9 +369,9 @@ def test_buildx_inspect_bootstrap():
     my_builder = docker.buildx.create()
     with my_builder:
         docker.buildx.inspect(my_builder.name, bootstrap=True)
-        assert my_builder.status == "running"
+        assert my_builder.nodes[0].status == "running"
         # Must contain at least the host native platform
-        assert my_builder.platforms
+        assert my_builder.nodes[0].platforms
 
 
 def test_builder_name():
@@ -488,13 +488,13 @@ def test_buildx_create_bootstrap():
     with my_builder:
         assert my_builder.nodes[0].status == "running"
         # Must contain at least the host native platform
-        assert my_builder.platforms
+        assert my_builder.node[0].platforms
 
 
 def test_buildx_create_remove_with_platforms():
     builder = docker.buildx.create(platforms=["linux/amd64", "linux/arm64"])
 
-    assert builder.platforms == ["linux/amd64*", "linux/arm64*"]
+    assert builder.node[0].platforms == ["linux/amd64*", "linux/arm64*"]
 
     docker.buildx.remove(builder)
 

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -494,7 +494,7 @@ def test_buildx_create_bootstrap():
 def test_buildx_create_remove_with_platforms():
     builder = docker.buildx.create(platforms=["linux/amd64", "linux/arm64"])
 
-    assert builder.nodes[0].platforms == ["linux/amd64*", "linux/arm64*"]
+    assert builder.nodes[0].platforms == ["linux/amd64", "linux/arm64"]
 
     docker.buildx.remove(builder)
 

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -487,7 +487,7 @@ def test_buildx_create_remove():
 def test_buildx_create_bootstrap():
     my_builder = docker.buildx.create(bootstrap=True)
     with my_builder:
-        assert my_builder.status == "running"
+        assert my_builder.nodes[0].status == "running"
         # Must contain at least the host native platform
         assert my_builder.platforms
 

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -488,13 +488,13 @@ def test_buildx_create_bootstrap():
     with my_builder:
         assert my_builder.nodes[0].status == "running"
         # Must contain at least the host native platform
-        assert my_builder.node[0].platforms
+        assert my_builder.nodes[0].platforms
 
 
 def test_buildx_create_remove_with_platforms():
     builder = docker.buildx.create(platforms=["linux/amd64", "linux/arm64"])
 
-    assert builder.node[0].platforms == ["linux/amd64*", "linux/arm64*"]
+    assert builder.nodes[0].platforms == ["linux/amd64*", "linux/arm64*"]
 
     docker.buildx.remove(builder)
 

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -4,7 +4,6 @@ import tarfile
 import pytest
 
 from python_on_whales import docker
-from python_on_whales.components.buildx.models import BuilderInspectResult
 from python_on_whales.exceptions import DockerException
 from python_on_whales.test_utils import set_cache_validity_period
 from python_on_whales.utils import PROJECT_ROOT
@@ -498,45 +497,6 @@ def test_buildx_create_remove_with_platforms():
     assert builder.platforms == ["linux/amd64*", "linux/arm64*"]
 
     docker.buildx.remove(builder)
-
-
-some_builder_info = """
-Name:   blissful_swartz
-Driver: docker-container
-
-Nodes:
-Name:      blissful_swartz0
-Endpoint:  unix:///var/run/docker.sock
-Status:    inactive
-Platforms:
-"""
-
-some_builder_info_with_platforms = """
-Name:   blissful_swartz
-Driver: docker-container
-
-Nodes:
-Name:      blissful_swartz0
-Endpoint:  unix:///var/run/docker.sock
-Status:    running
-Platforms: linux/amd64, linux/arm64
-"""
-
-
-def test_builder_inspect_result_from_string():
-    a = BuilderInspectResult.from_str(some_builder_info)
-    assert a.name == "blissful_swartz"
-    assert a.driver == "docker-container"
-    assert a.status == "inactive"
-    assert a.platforms == []
-
-
-def test_builder_inspect_result_platforms_from_string():
-    a = BuilderInspectResult.from_str(some_builder_info_with_platforms)
-    assert a.name == "blissful_swartz"
-    assert a.driver == "docker-container"
-    assert a.status == "running"
-    assert a.platforms == ["linux/amd64", "linux/arm64"]
 
 
 bake_test_dir = PROJECT_ROOT / "tests/python_on_whales/components/bake_tests"


### PR DESCRIPTION
Fix https://github.com/gabrieldemarmiesse/python-on-whales/issues/667
Supersedes https://github.com/gabrieldemarmiesse/python-on-whales/pull/668

Here is an example of usage:

```
$ uv run --with ipython ipython
Python 3.8.20 (default, Oct  2 2024, 16:34:12)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.12.3 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from python_on_whales import docker

In [2]: some_builder = docker.buildx.create()

In [3]: docker.buildx.create("ssh://xxxx", append=True, name=some_builder.name)
Out[3]: python_on_whales.Builder(name='reverent_cray', driver='docker-container')

In [4]: docker.buildx.list()
Out[4]:
[python_on_whales.Builder(name='default', driver='docker'),
 python_on_whales.Builder(name='reverent_cray', driver='docker-container'),
 python_on_whales.Builder(name='quirky_blackburn', driver='docker-container')]

In [5]: docker.buildx.list()[1].nodes
Out[5]:
[BuilderNode(name='reverent_cray0', endpoint='unix:///var/run/docker.sock', flags=['--allow-insecure-entitlement=network.host'], status='inactive', version=None, ids=None, platforms=None, labels=None),
 BuilderNode(name='reverent_cray1', endpoint='ssh://xxxxxxx', flags=['--allow-insecure-entitlement=network.host'], status='inactive', version=None, ids=None, platforms=None, labels=None)]
```
This requires buildx version >= [v0.13.0](https://github.com/docker/buildx/releases/tag/v0.13.0)

@rico132 this should fix all the issues you have with multi-nodes builders :) 

Also added more info in the docs about the builders