### PR TITLE
Stream output from `pull` and `push` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-on-whales"
-version = "0.76.1"
+version = "0.77.0"
 description = "A Docker client for Python, designed to be fun and intuitive!"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -544,7 +544,7 @@ class ImageCLI(DockerCLICaller):
 
         images = list(dict.fromkeys(x))
         if len(images) == 0:
-            return () if stream_logs else []
+            return (_ for _ in []) if stream_logs else []
         if len(images) == 1:
             image, *_ = images
             result = self._pull_single_tag(

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -593,7 +593,7 @@ class ImageCLI(DockerCLICaller):
                 "Only one can be activated at a time."
             )
 
-        images = to_list(x)
+        images = list(dict.fromkeys(to_list(x)))
 
         # this is just to raise a correct exception if the images don't exist
         self.inspect(images)

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -506,49 +506,131 @@ class ImageCLI(DockerCLICaller):
         self,
         x: Union[str, Iterable[str]],
         quiet: bool = False,
+        stream_logs: bool = False,
         platform: Optional[str] = None,
-    ) -> Union[Image, List[Image]]:
+    ) -> Union[Image, List[Image], Iterable[Tuple[str, bytes]]]:
         """Pull one or more docker image(s)
 
         Alias: `docker.pull(...)`
 
         Parameters:
-            x: The image name(s) . Can be a string or a list of strings. In case of
-                list, multithreading is used to pull the images.
-                The progress bars might look strange as multiple
-                processes are drawing on the terminal at the same time.
+            x: Image name(s), can be a string or a list of strings.
+                In case a list is passed, multithreading is used to pull
+                the images.
             quiet: If you don't want to see the progress bars.
+            stream_logs: If `False` this function returns the pulled image(s).
+                If `True`, this function returns an `Iterable` of `Tuple[str, bytes]`
+                where the first element corresponds to the image name that a pull is being done for.
+                The second element is the log statement related to pull progress, as `bytes`.
+                You'll need to call `.decode()` if you want the logs as `str`.
+                See [the streaming guide](https://gabrieldemarmiesse.github.io/python-on-whales/user_guide/docker_run/#stream-the-output)
+                if you are not familiar with the streaming of logs in Python-on-whales.
             platform: If you want to enforce a platform.
-
-        Returns:
-            The Docker image loaded (`python_on_whales.Image` object).
-            If a list was passed as input, then a `List[python_on_whales.Image]` will
-            be returned.
         """
+        if quiet and stream_logs:
+            raise ValueError(
+                "It's not possible to have stream_logs=True and quiet=True at the same time. "
+                "Only one can be activated at a time."
+            )
+
         if isinstance(x, str):
-            return self._pull_single_tag(x, quiet=quiet, platform=platform)
-        x = list(x)
-        if not x:
-            return []
-        if len(x) == 1:
-            return [self._pull_single_tag(x[0], quiet=quiet, platform=platform)]
+            result = self._pull_single_tag(
+                image_name=x,
+                quiet=quiet,
+                stream_logs=stream_logs,
+                platform=platform,
+            )
+            return result if stream_logs else Image(self.client_config, x)
+
+        images = list(dict.fromkeys(x))
+        if len(images) == 0:
+            return () if stream_logs else []
+        if len(images) == 1:
+            image, *_ = images
+            result = self._pull_single_tag(
+                image_name=image,
+                quiet=quiet,
+                stream_logs=stream_logs,
+                platform=platform,
+            )
+            return result if stream_logs else [Image(self.client_config, image)]
+        else:
+            return self._pull_multiple_tags(
+                image_names=images,
+                quiet=quiet,
+                stream_logs=stream_logs,
+                platform=platform,
+            )
+
+    def _pull_multiple_tags(
+        self,
+        image_names: List[str],
+        quiet: bool,
+        stream_logs: bool = False,
+        platform: Optional[str] = None,
+    ) -> Union[List[Image], Iterable[Tuple[str, bytes]]]:
+        if stream_logs:
+            return self._pull_multiple_tags_stream(
+                image_names=image_names,
+                quiet=quiet,
+                stream_logs=stream_logs,
+                platform=platform,
+            )
         else:
             pool = ThreadPool(4)
-            generator = self._generate_args_pull(x, quiet, platform)
-            all_images = pool.starmap(self._pull_single_tag, generator)
+            pool.starmap(
+                func=self._pull_single_tag,
+                iterable=(
+                    (image_name, quiet, stream_logs, platform)
+                    for image_name in image_names
+                ),
+            )
             pool.close()
             pool.join()
-            return all_images
+            return [Image(self.client_config, image_name) for image_name in image_names]
 
-    def _generate_args_pull(
-        self, _list: Iterable[str], quiet: bool, platform: Optional[str] = None
+    def _pull_multiple_tags_stream(
+        self,
+        image_names: List[str],
+        quiet: bool,
+        stream_logs: bool = False,
+        platform: Optional[str] = None,
     ):
-        for tag in _list:
-            yield tag, quiet, platform
+        queue = Queue()
+
+        def _pull_and_queue_logs(image_name: str):
+            if generator := self._pull_single_tag(
+                image_name, quiet, stream_logs, platform
+            ):
+                for value in generator:
+                    queue.put(value)
+            queue.put(None)  # Signal completion
+
+        with ThreadPoolExecutor(4) as executor:
+            futures = [
+                executor.submit(_pull_and_queue_logs, image_name)
+                for image_name in image_names
+            ]
+
+            completed = 0
+            while completed < len(image_names):
+                try:
+                    if item := queue.get(timeout=0.1):
+                        yield item
+                    else:
+                        completed += 1
+                except EmptyQueue:
+                    continue
+
+            [future.result() for future in futures]
 
     def _pull_single_tag(
-        self, image_name: str, quiet: bool, platform: Optional[str] = None
-    ):
+        self,
+        image_name: str,
+        quiet: bool,
+        stream_logs: bool = False,
+        platform: Optional[str] = None,
+    ) -> Optional[Iterable[Tuple[str, bytes]]]:
         full_cmd = self.docker_cmd + ["image", "pull"]
 
         if quiet:
@@ -558,8 +640,14 @@ class ImageCLI(DockerCLICaller):
             full_cmd.append(f"--platform={platform}")
 
         full_cmd.append(image_name)
-        run(full_cmd, capture_stdout=quiet, capture_stderr=quiet)
-        return Image(self.client_config, image_name)
+
+        if stream_logs:
+            return (
+                (image_name, line) for _, line in stream_stdout_and_stderr(full_cmd)
+            )
+        else:
+            run(full_cmd, capture_stdout=quiet, capture_stderr=quiet)
+            return None
 
     def push(
         self,

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -540,7 +540,7 @@ class ImageCLI(DockerCLICaller):
             )
             return result if stream_logs else Image(self.client_config, x)
 
-        images = list(x)
+        images = list(set(x))
         if len(images) == 0:
             return (_ for _ in []) if stream_logs else []
         if len(images) == 1:

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -599,12 +599,14 @@ class ImageCLI(DockerCLICaller):
         queue = Queue()
 
         def _pull_and_queue_logs(image_name: str):
-            if generator := self._pull_single_tag(
-                image_name, quiet, stream_logs, platform
-            ):
-                for value in generator:
-                    queue.put(value)
-            queue.put(None)  # Signal completion
+            try:
+                if generator := self._pull_single_tag(
+                    image_name, quiet, stream_logs, platform
+                ):
+                    for value in generator:
+                        queue.put(value)
+            finally:
+                queue.put(None)  # Signal completion
 
         with ThreadPoolExecutor(4) as executor:
             futures = [
@@ -735,10 +737,12 @@ class ImageCLI(DockerCLICaller):
         queue = Queue()
 
         def _push_and_queue_logs(tag_or_repo: str):
-            if generator := self._push_single_tag(tag_or_repo, quiet, stream_logs):
-                for value in generator:
-                    queue.put(value)
-            queue.put(None)  # Signal completion
+            try:
+                if generator := self._push_single_tag(tag_or_repo, quiet, stream_logs):
+                    for value in generator:
+                        queue.put(value)
+            finally:
+                queue.put(None)  # Signal completion
 
         with ThreadPoolExecutor(4) as executor:
             futures = [

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -523,8 +523,6 @@ class ImageCLI(DockerCLICaller):
                 where the first element corresponds to the image name that a pull is being done for.
                 The second element is the log statement related to pull progress, as `bytes`.
                 You'll need to call `.decode()` if you want the logs as `str`.
-                See [the streaming guide](https://gabrieldemarmiesse.github.io/python-on-whales/user_guide/docker_run/#stream-the-output)
-                if you are not familiar with the streaming of logs in Python-on-whales.
             platform: If you want to enforce a platform.
         """
         if quiet and stream_logs:
@@ -671,8 +669,6 @@ class ImageCLI(DockerCLICaller):
                 corresponds to the image or repository name that a push is being done for.
                 The second element is the log statement related to push progress, as `bytes`.
                 You'll need to call `.decode()` if you want the logs as `str`.
-                See [the streaming guide](https://gabrieldemarmiesse.github.io/python-on-whales/user_guide/docker_run/#stream-the-output)
-                if you are not familiar with the streaming of logs in Python-on-whales.
 
         # Raises
             `python_on_whales.exceptions.NoSuchImage` if one of the images does not exist.


### PR DESCRIPTION
Support streaming output from the `pull` and `push` commands.

## Pulling

Minimal reproducible example of pulling multiple images with log streaming:

```python
import logging
from logging import INFO, Formatter, StreamHandler
from sys import stdout

from python_on_whales import docker

formatter = Formatter("%(asctime)s [%(levelname)s] %(message)s")
handler = StreamHandler(stream=stdout)
logger = logging.getLogger(__file__)
logger.setLevel(INFO)
handler.setFormatter(formatter)
logger.addHandler(handler)

images = [
    "registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1",
    "registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2",
]

if __name__ == '__main__':
    if generator := docker.image.pull(images, stream_logs=True):
        for image, line in generator:
            logger.info("[%s] %s", image, line.decode(errors="replace").strip())
```

Produces the following output:

```
2025-06-07 12:53:54,627 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 1: Pulling from p/ml-4-se-lab/python-on-whales/test
2025-06-07 12:53:54,661 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 2: Pulling from p/ml-4-se-lab/python-on-whales/test
2025-06-07 12:53:55,693 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 771aa65b5adb: Pulling fs layer
2025-06-07 12:53:55,693 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Pulling fs layer
2025-06-07 12:53:55,703 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 771aa65b5adb: Pulling fs layer
2025-06-07 12:53:55,703 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] d69d4d41cfe2: Pulling fs layer
2025-06-07 12:53:57,139 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 771aa65b5adb: Download complete
2025-06-07 12:53:57,139 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] d69d4d41cfe2: Download complete
2025-06-07 12:53:57,150 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 771aa65b5adb: Download complete
2025-06-07 12:53:57,150 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Download complete
2025-06-07 12:53:57,171 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 771aa65b5adb: Pull complete
2025-06-07 12:53:57,173 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 771aa65b5adb: Pull complete
2025-06-07 12:53:57,174 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Pull complete
2025-06-07 12:53:57,174 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] Digest: sha256:484d7d8f6639713a572ded4562fd1106acb69424b7d218bac0944406c279396a
2025-06-07 12:53:57,174 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] Status: Downloaded newer image for registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1
2025-06-07 12:53:57,176 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1
2025-06-07 12:53:57,179 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] d69d4d41cfe2: Pull complete
2025-06-07 12:53:57,179 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] Digest: sha256:c02bb7a2b95fdffc7e0dd75157260ed38df4a81a8cc1e9412a42441ebfb28e9d
2025-06-07 12:53:57,179 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] Status: Downloaded newer image for registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2
2025-06-07 12:53:57,180 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2
```

## Pushing

Minimal reproducible example of pushing multiple images with log streaming:

```python
import logging
from logging import INFO, Formatter, StreamHandler
from sys import stdout

from python_on_whales import docker

formatter = Formatter("%(asctime)s [%(levelname)s] %(message)s")
handler = StreamHandler(stream=stdout)
logger = logging.getLogger(__file__)
logger.setLevel(INFO)
handler.setFormatter(formatter)
logger.addHandler(handler)

images = [
    "registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1",
    "registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2",
]

if __name__ == '__main__':
    if generator := docker.image.push(images, stream_logs=True):
        for image, line in generator:
            logger.info("[%s] %s", image, line.decode(errors="replace").strip())
```

Produces the following output:

```
2025-06-01 19:26:35,408 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] The push refers to repository [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test]
2025-06-01 19:26:35,418 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] The push refers to repository [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test]
2025-06-01 19:26:35,515 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 667acca900bd: Waiting
2025-06-01 19:26:35,515 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 771aa65b5adb: Waiting
2025-06-01 19:26:35,515 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Waiting
2025-06-01 19:26:35,521 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 0428fa5aaf34: Waiting
2025-06-01 19:26:35,521 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 771aa65b5adb: Waiting
2025-06-01 19:26:35,521 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] d69d4d41cfe2: Waiting
2025-06-01 19:26:35,613 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 771aa65b5adb: Waiting
2025-06-01 19:26:35,613 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Waiting
2025-06-01 19:26:35,613 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 667acca900bd: Waiting
2025-06-01 19:26:35,619 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 0428fa5aaf34: Waiting
2025-06-01 19:26:35,620 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 771aa65b5adb: Waiting
2025-06-01 19:26:35,620 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] d69d4d41cfe2: Waiting
2025-06-01 19:26:35,712 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 667acca900bd: Waiting
2025-06-01 19:26:35,712 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 771aa65b5adb: Waiting
2025-06-01 19:26:35,712 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Waiting
2025-06-01 19:26:35,720 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 0428fa5aaf34: Waiting
2025-06-01 19:26:35,720 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 771aa65b5adb: Waiting
2025-06-01 19:26:35,720 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] d69d4d41cfe2: Waiting
2025-06-01 19:26:35,816 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 667acca900bd: Waiting
2025-06-01 19:26:35,816 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 771aa65b5adb: Waiting
2025-06-01 19:26:35,816 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Waiting
2025-06-01 19:26:35,820 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 0428fa5aaf34: Waiting
2025-06-01 19:26:35,820 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 771aa65b5adb: Waiting
2025-06-01 19:26:35,820 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] d69d4d41cfe2: Waiting
2025-06-01 19:26:35,911 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 771aa65b5adb: Layer already exists
2025-06-01 19:26:35,911 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Waiting
2025-06-01 19:26:35,911 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 667acca900bd: Waiting
2025-06-01 19:26:35,921 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 0428fa5aaf34: Waiting
2025-06-01 19:26:35,921 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 771aa65b5adb: Waiting
2025-06-01 19:26:35,921 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] d69d4d41cfe2: Layer already exists
2025-06-01 19:26:36,010 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 667acca900bd: Waiting
2025-06-01 19:26:36,010 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Waiting
2025-06-01 19:26:36,020 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 0428fa5aaf34: Already exists
2025-06-01 19:26:36,020 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 771aa65b5adb: Layer already exists
2025-06-01 19:26:36,111 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 667acca900bd: Already exists
2025-06-01 19:26:36,111 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] d69d4d41cfe2: Layer already exists
2025-06-01 19:26:37,106 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:1] 1: digest: sha256:484d7d8f6639713a572ded4562fd1106acb69424b7d218bac0944406c279396a size: 855
2025-06-01 19:26:37,109 [INFO] [registry.jetbrains.team/p/ml-4-se-lab/python-on-whales/test:2] 2: digest: sha256:c02bb7a2b95fdffc7e0dd75157260ed38df4a81a8cc1e9412a42441ebfb28e9d size: 855
```

## Notes

I've also updated both methods to filter duplicates from the image list while preserving the order in which they were specified.

Fixes #677