### PR TITLE
Allow customization of `--isolation` and `--quiet` in `legacy_build`

### DIFF
--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -252,6 +252,7 @@ class ImageCLI(DockerCLICaller):
         tags: Union[str, Iterable[str]] = (),
         target: Optional[str] = None,
         isolation: Optional[str] = None,
+        quiet: bool = True,
     ) -> python_on_whales.components.image.cli_wrapper.Image:
         """Build a Docker image with the old Docker builder (meaning not using buildx/buildkit)
 
@@ -284,14 +285,15 @@ class ImageCLI(DockerCLICaller):
             tags: Tag or tags to put on the resulting image.
             target: Set the target build stage to build.
             isolation: Specify isolation technology for container (useful for Windows).
+            quiet: If you don't want to display the progress bars.
 
         # Returns
             A `python_on_whales.Image`
         """
         # to make it easier to write and read tests, the tests of this function
         # are also grouped with the tests of "docker.build()".
-        full_cmd = self.docker_cmd + ["build", "--quiet"]
-
+        full_cmd = self.docker_cmd + ["build"]
+        full_cmd.add_flag("--quiet", quiet)
         full_cmd.add_args_mapping("--add-host", add_hosts, separator=":")
         full_cmd.add_args_mapping("--build-arg", build_args)
         full_cmd.add_args_mapping("--label", labels)
@@ -307,8 +309,19 @@ class ImageCLI(DockerCLICaller):
             self.client_config
         )
         full_cmd.append(context_path)
-        image_id = run(full_cmd).splitlines()[-1].strip()
-        return docker_image.inspect(image_id)
+        if quiet:
+            image_id = run(full_cmd).splitlines()[-1].strip()
+            return docker_image.inspect(image_id)
+        else:
+            for (_, line) in stream_stdout_and_stderr(full_cmd):
+                try:
+                    line = line.decode().rstrip()
+                except UnicodeDecodeError:
+                    line = str(line)
+                print(line)
+                if "Successfully built" in line:
+                    image_id = line.split(" ")[-1]
+            return docker_image.inspect(image_id)
 
     def history(self):
         """Not yet implemented"""

--- a/python_on_whales/components/image/cli_wrapper.py
+++ b/python_on_whales/components/image/cli_wrapper.py
@@ -251,6 +251,7 @@ class ImageCLI(DockerCLICaller):
         pull: bool = False,
         tags: Union[str, Iterable[str]] = (),
         target: Optional[str] = None,
+        isolation: Optional[str] = None,
     ) -> python_on_whales.components.image.cli_wrapper.Image:
         """Build a Docker image with the old Docker builder (meaning not using buildx/buildkit)
 
@@ -282,6 +283,7 @@ class ImageCLI(DockerCLICaller):
             pull: Always attempt to pull a newer version of the image
             tags: Tag or tags to put on the resulting image.
             target: Set the target build stage to build.
+            isolation: Specify isolation technology for container (useful for Windows).
 
         # Returns
             A `python_on_whales.Image`
@@ -299,6 +301,7 @@ class ImageCLI(DockerCLICaller):
         full_cmd.add_simple_arg("--network", network)
         full_cmd.add_flag("--no-cache", not cache)
         full_cmd.add_args_iterable_or_single("--tag", tags)
+        full_cmd.add_simple_arg("--isolation", isolation)
 
         docker_image = python_on_whales.components.image.cli_wrapper.ImageCLI(
             self.client_config


### PR DESCRIPTION
The legacy builder is still useful for Windows scenarios not yet fully supported by BuildKit.

This change opens up a couple options for the users of `legacy_build`:

- Add support to `--isolation`: this is necessary to enable Hyper-V isolation.
- Allow `--quiet` to be unset: for easier debugging.