### PR TITLE
Add metadata_file opt-in for buildx builds

### DIFF
--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -243,7 +243,7 @@ class BuildxCLI(DockerCLICaller):
         file: Optional[ValidPath] = None,
         labels: Dict[str, str] = {},
         load: bool = False,
-        # TODO: metadata_file
+        metadata_file: Optional[ValidPath] = None,
         network: Optional[str] = None,
         output: Dict[str, str] = {},
         platforms: Optional[List[str]] = None,
@@ -328,6 +328,8 @@ class BuildxCLI(DockerCLICaller):
             target: Set the target build stage to build.
             stream_logs: If `True` this function will return an iterator of strings.
                 You can then read the logs as they arrive.
+            metadata_file: Path where build metadata should be written. Equivalent
+                to the CLI flag `--metadata-file` and only used when provided.
 
         # Returns
             A `python_on_whales.Image` if a Docker image is loaded
@@ -368,6 +370,7 @@ class BuildxCLI(DockerCLICaller):
         elif isinstance(sbom, dict):
             full_cmd.add_simple_arg("--sbom", format_dict_for_buildx(sbom))
         full_cmd.add_flag("--load", load)
+        full_cmd.add_simple_arg("--metadata-file", metadata_file)
         full_cmd.add_simple_arg("--file", file)
         full_cmd.add_simple_arg("--target", target)
         if isinstance(cache_from, list):


### PR DESCRIPTION
Closes #688

### Summary:
- add an opt-in metadata_file argument to `docker.buildx.build()` and pipe it to the CLI’s `--metadata-file`
- cover the new flag with unit tests and validate the integration flow by capturing metadata during the push test

### Note:
I explored the [broader DX idea (always enabling `--metadata-file` and parsing the result with Pydantic)](https://github.com/gabrieldemarmiesse/python-on-whales/issues/688#issuecomment-3396808594) but the blast radius ended up much larger than expected—touching return types, context managers, and many integration tests.
To keep the change manageable, this PR sticks to the opt-in flag so we can unblock digest retrieval without breaking existing workflows.