### PR TITLE
Add support for --disable-dns when creating a network (podman)

### DIFF
--- a/python_on_whales/components/network/cli_wrapper.py
+++ b/python_on_whales/components/network/cli_wrapper.py
@@ -202,6 +202,7 @@ class NetworkCLI(DockerCLICaller):
         self,
         name: str,
         attachable: bool = False,
+        disable_dns: bool = False,
         driver: Optional[str] = None,
         gateway: Optional[str] = None,
         subnet: Optional[str] = None,
@@ -218,6 +219,7 @@ class NetworkCLI(DockerCLICaller):
         """
         full_cmd = self.docker_cmd + ["network", "create"]
         full_cmd.add_flag("--attachable", attachable)
+        full_cmd.add_flag("--disable-dns", disable_dns)
         full_cmd.add_simple_arg("--driver", driver)
         full_cmd.add_simple_arg("--gateway", gateway)
         full_cmd.add_simple_arg("--subnet", subnet)

--- a/python_on_whales/components/network/cli_wrapper.py
+++ b/python_on_whales/components/network/cli_wrapper.py
@@ -128,6 +128,10 @@ class Network(ReloadableObjectFromJson):
     def config_only(self) -> bool:
         return self._get_inspect_result().config_only
 
+    @property
+    def dns_enabled(self) -> bool:
+        return self._get_inspect_result().dns_enabled
+
     def __repr__(self):
         return f"python_on_whales.Network(id='{self.id[:12]}', name={self.name})"
 
@@ -213,6 +217,7 @@ class NetworkCLI(DockerCLICaller):
 
         Parameters:
             name: The name of the network
+            disable_dns: A podman only option to disable the dns plugin
 
         # Returns
             A `python_on_whales.Network`.

--- a/python_on_whales/components/network/models.py
+++ b/python_on_whales/components/network/models.py
@@ -34,3 +34,4 @@ class NetworkInspectResult(DockerCamelModel):
     labels: Optional[Dict[str, str]] = None
     config_from: Optional[dict] = None
     config_only: Optional[bool] = None
+    dns_enabled: Optional[bool] = None

--- a/tests/python_on_whales/components/test_network.py
+++ b/tests/python_on_whales/components/test_network.py
@@ -136,3 +136,15 @@ def test_correct_ipam_config(docker_client: DockerClient):
             ].ipam_config == ContainerEndpointIPAMConfig(
                 ipv4_address="172.20.0.5", ipv6_address=None, link_local_ips=None
             )
+
+
+def test_disable_dns(podman_client: DockerClient):
+    with podman_client.network.create(random_name(), disable_dns=False) as net:
+        assert net.dns_enabled is True
+        inspect_result = podman_client.network.inspect(net.name)
+        assert inspect_result.dns_enabled is True
+
+    with podman_client.network.create(random_name(), disable_dns=True) as net:
+        assert net.dns_enabled is False
+        inspect_result = podman_client.network.inspect(net.name)
+        assert inspect_result.dns_enabled is False


### PR DESCRIPTION
`podman network create` has an option to disable creating a dns process when making bridge networks, see documentation [here](https://docs.podman.io/en/latest/markdown/podman-network-create.1.html). As far as I can tell docker doesn't have this flag?