### PR TITLE
Add stdin support for interactive containers

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -1002,8 +1002,9 @@ class ContainerCLI(DockerCLICaller):
             env_files: Read one or more files of environment variables
             interactive: Leave stdin open during the duration of the process
                 to allow communication with the parent process.
-                Currently only works with `tty=True` for interactive use
-                on the terminal.
+                Can be combined with `stream=True` to get an
+                `ProcessStream` that allows writing to stdin while
+                iterating over stdout/stderr.
             preserve_fds: The number of additional file descriptors to pass
                 through to the container. Only supported by podman.
             privileged: Give extended privileges to the container.
@@ -1041,12 +1042,6 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_args_mapping("--env", envs)
         full_cmd.add_args_iterable_or_single("--env-file", env_files)
 
-        if interactive and stream:
-            raise ValueError(
-                "You can't set interactive=True and stream=True at the same"
-                "time. Their purpose are not compatible."
-            )
-
         if tty and stream:
             raise ValueError(
                 "You can't set tty=True and stream=True at the same"
@@ -1077,7 +1072,9 @@ class ContainerCLI(DockerCLICaller):
         else:
             pass_fds = ()
         if stream:
-            return stream_stdout_and_stderr(full_cmd, pass_fds=pass_fds)
+            return stream_stdout_and_stderr(
+                full_cmd, pass_fds=pass_fds, pipe_stdin=interactive
+            )
         else:
             result = run(full_cmd, tty=tty, pass_fds=pass_fds)
             if detach:

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -12,9 +12,9 @@ from queue import Queue
 from subprocess import PIPE, Popen
 from threading import Thread
 from typing import (
+    IO,
     Any,
     Dict,
-    IO,
     Iterable,
     Iterator,
     List,

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -14,7 +14,9 @@ from threading import Thread
 from typing import (
     Any,
     Dict,
+    IO,
     Iterable,
+    Iterator,
     List,
     Mapping,
     Optional,
@@ -263,9 +265,31 @@ def reader(pipe, pipe_name, queue):
         queue.put(None)
 
 
-def stream_stdout_and_stderr(
-    full_cmd: list, env: Dict[str, str] = None, pass_fds: Sequence[int] = ()
-) -> Iterable[Tuple[str, bytes]]:
+class ProcessStream(Iterable[Tuple[str, bytes]]):
+    """Wrapper around a streaming subprocess that also exposes stdin.
+
+    Iterating over a ``ProcessStream`` yields ``(source, line)`` tuples.
+    """
+
+    def __init__(
+        self,
+        iterator: Iterable[Tuple[str, bytes]],
+        stdin: Optional[IO[bytes]] = None,
+    ) -> None:
+        self.iterator: Iterable[Tuple[str, bytes]] = iterator
+        self.stdin: Optional[IO[bytes]] = stdin
+
+    def __iter__(self) -> Iterator[Tuple[str, bytes]]:
+        return iter(self.iterator)
+
+
+def _start_process(
+    full_cmd: list,
+    env: Dict[str, str] = None,
+    pass_fds: Sequence[int] = (),
+    pipe_stdin: bool = False,
+) -> Tuple[Popen, Queue]:
+    """Start a subprocess and wire up reader threads for stdout/stderr."""
     if env is None:
         subprocess_env = None
     else:
@@ -274,10 +298,14 @@ def stream_stdout_and_stderr(
 
     full_cmd = list(map(str, full_cmd))
     process = Popen(
-        full_cmd, stdout=PIPE, stderr=PIPE, env=subprocess_env, pass_fds=pass_fds
+        full_cmd,
+        stdin=PIPE if pipe_stdin else None,
+        stdout=PIPE,
+        stderr=PIPE,
+        env=subprocess_env,
+        pass_fds=pass_fds,
     )
-    q = Queue()
-    full_stderr = b""  # for the error message
+    q: Queue = Queue()
     # we use deamon threads to avoid hanging if the user uses ctrl+c
     th = Thread(target=reader, args=[process.stdout, "stdout", q])
     th.daemon = True
@@ -285,6 +313,14 @@ def stream_stdout_and_stderr(
     th = Thread(target=reader, args=[process.stderr, "stderr", q])
     th.daemon = True
     th.start()
+    return process, q
+
+
+def _iter_process(
+    process: Popen, q: Queue, full_cmd: list
+) -> Iterable[Tuple[str, bytes]]:
+    """Iterate stdout/stderr from a non-interactive process."""
+    full_stderr = b""
     for _ in range(2):
         for source, line in iter(q.get, None):
             yield source, line
@@ -297,6 +333,24 @@ def stream_stdout_and_stderr(
         raise exception_type(
             command_launched=full_cmd, return_code=exit_code, stderr=full_stderr
         )
+
+
+def stream_stdout_and_stderr(
+    full_cmd: list,
+    env: Dict[str, str] = None,
+    pass_fds: Sequence[int] = (),
+    pipe_stdin: bool = False,
+) -> Iterable[Tuple[str, bytes]]:
+    """Stream stdout/stderr from a subprocess.
+
+    Always returns a :class:`ProcessStream`.  When *pipe_stdin* is
+    ``True`` the subprocess is started with ``stdin=PIPE`` so that
+    ``result.stdin`` is available for writing.  Otherwise ``result.stdin``
+    is ``None``.
+    """
+    process, q = _start_process(full_cmd, env, pass_fds, pipe_stdin)
+    full_cmd = list(map(str, full_cmd))
+    return ProcessStream(_iter_process(process, q, full_cmd), process.stdin)
 
 
 def format_mapping_for_cli(mapping: Mapping[str, str], separator="="):

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -509,6 +509,21 @@ def test_execute_stream(ctr_client: DockerClient):
     ctr_client.kill(my_container)
 
 
+@pytest.mark.parametrize("ctr_client", ["docker", "podman"], indirect=True)
+def test_execute_interactive_stream(ctr_client: DockerClient):
+    my_container = ctr_client.run(
+        "busybox:1", ["sleep", "infinity"], detach=True, remove=True
+    )
+    proc = ctr_client.execute(
+        my_container, ["cat"], interactive=True, stream=True
+    )
+    proc.stdin.write(b"hello\n")
+    proc.stdin.close()
+    output = list(proc)
+    assert ("stdout", b"hello\n") in output
+    ctr_client.kill(my_container)
+
+
 @pytest.mark.parametrize(
     "ctr_client",
     ["docker", pytest.param("podman", marks=pytest.mark.xfail)],

--- a/tests/python_on_whales/components/test_container.py
+++ b/tests/python_on_whales/components/test_container.py
@@ -514,9 +514,7 @@ def test_execute_interactive_stream(ctr_client: DockerClient):
     my_container = ctr_client.run(
         "busybox:1", ["sleep", "infinity"], detach=True, remove=True
     )
-    proc = ctr_client.execute(
-        my_container, ["cat"], interactive=True, stream=True
-    )
+    proc = ctr_client.execute(my_container, ["cat"], interactive=True, stream=True)
     proc.stdin.write(b"hello\n")
     proc.stdin.close()
     output = list(proc)

--- a/tests/python_on_whales/test_utils.py
+++ b/tests/python_on_whales/test_utils.py
@@ -1,4 +1,5 @@
 import python_on_whales.utils
+from python_on_whales.utils import ProcessStream, stream_stdout_and_stderr
 
 
 def test_environment_variables_propagation(monkeypatch):
@@ -10,3 +11,32 @@ def test_environment_variables_propagation(monkeypatch):
         env={"OTHER_VARIABLE": "dudu"},
     )
     assert stdout == "dododada\ndudu"
+
+
+def test_stream_stdout_and_stderr_interactive():
+    proc = stream_stdout_and_stderr(["cat"], pipe_stdin=True)
+    assert isinstance(proc, ProcessStream)
+    proc.stdin.write(b"hello world\n")
+    proc.stdin.close()
+    output = list(proc)
+    assert ("stdout", b"hello world\n") in output
+
+
+def test_stream_stdout_and_stderr_interactive_multiple_lines():
+    proc = stream_stdout_and_stderr(["cat"], pipe_stdin=True)
+    proc.stdin.write(b"line1\n")
+    proc.stdin.write(b"line2\n")
+    proc.stdin.close()
+    output = list(proc)
+    stdout_lines = [line for source, line in output if source == "stdout"]
+    assert b"line1\n" in stdout_lines
+    assert b"line2\n" in stdout_lines
+
+
+def test_stream_stdout_and_stderr_non_interactive():
+    """Non-interactive mode returns ProcessStream with stdin=None."""
+    result = stream_stdout_and_stderr(["echo", "hi"])
+    assert isinstance(result, ProcessStream)
+    assert result.stdin is None
+    output = list(result)
+    assert ("stdout", b"hi\n") in output


### PR DESCRIPTION
# Add stdin support for interactive streaming containers

## Summary

Allow `interactive=True` and `stream=True` to be used together in `docker.execute()`. This enables programmatic bidirectional communication with a running container — writing to stdin while streaming stdout/stderr.

Previously, combining these flags raised a `ValueError` because the original implementation treated interactive mode as a TTY-only feature. However, there are valid use cases for piping stdin to a container process while streaming its output — for example, feeding input to a long-running subprocess and reacting to its output line-by-line.

## Changes

### `python_on_whales/utils.py`

- **`ProcessStream`** — New minimal wrapper class around the streaming iterator that also exposes the subprocess's `stdin` handle. Iterating over it yields `(source, line)` tuples just like before. When `pipe_stdin=False`, `stdin` is `None`.
- **`_start_process()`** — Extracted from `stream_stdout_and_stderr`. Starts the subprocess and wires up reader threads. Accepts a `pipe_stdin` flag to optionally open `stdin=PIPE`.
- **`_iter_process()`** — Extracted from `stream_stdout_and_stderr`. Generator that yields `(source, line)` tuples from the reader queue, then checks exit status.
- **`stream_stdout_and_stderr()`** — Now accepts `pipe_stdin` and always returns a `ProcessStream`.

### `python_on_whales/components/container/cli_wrapper.py`

- Removed the `ValueError` for `interactive=True, stream=True`.
- Passes `pipe_stdin=interactive` to `stream_stdout_and_stderr()`.
- Updated docstring to describe the new behavior.

### Tests

- **`test_utils.py`** — 3 new unit tests:
  - Interactive single-line write/read via `ProcessStream`
  - Interactive multi-line write/read
  - Non-interactive mode returns `ProcessStream` with `stdin=None`
- **`test_container.py`** — 1 new integration test:
  - `test_execute_interactive_stream` — runs `cat` in a container, writes to `proc.stdin`, and verifies the echoed output

## Usage

```python
container = docker.run("ubuntu", ["sleep", "infinity"], detach=True)

proc = docker.execute(container, ["cat"], interactive=True, stream=True)
proc.stdin.write(b"hello\n")
proc.stdin.close()

for source, line in proc:
    print(source, line)
# stdout b'hello\n'
```

## Backward Compatibility

No breaking changes. `stream_stdout_and_stderr()` now returns a `ProcessStream` instead of a bare generator, but `ProcessStream` implements `__iter__` so all existing iteration patterns continue to work. The `pipe_stdin` parameter defaults to `False`.
