### PR TITLE
Update secret component to accept args as Iterable and Mapping

### DIFF
--- a/python_on_whales/components/secret/cli_wrapper.py
+++ b/python_on_whales/components/secret/cli_wrapper.py
@@ -110,9 +110,7 @@ class SecretCLI(DockerCLICaller):
     @overload
     def inspect(self, x: Iterable[str]) -> List[Secret]: ...
 
-    def inspect(
-        self, x: Union[str, Iterable[str]]
-    ) -> Union[Secret, List[Secret]]:
+    def inspect(self, x: Union[str, Iterable[str]]) -> Union[Secret, List[Secret]]:
         """Returns one or more `python_on_whales.Secret` based on an ID or name.
 
         Parameters:

--- a/python_on_whales/components/secret/cli_wrapper.py
+++ b/python_on_whales/components/secret/cli_wrapper.py
@@ -11,6 +11,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    overload,
 )
 
 from typing_extensions import TypeAlias
@@ -88,7 +89,7 @@ class SecretCLI(DockerCLICaller):
         name: str,
         file: ValidPath,
         driver: Optional[str] = None,
-        labels: Dict[str, str] = {},
+        labels: Mapping[str, str] = {},
         template_driver: Optional[str] = None,
     ) -> Secret:
         """Creates a `python_on_whales.Secret`.
@@ -103,16 +104,24 @@ class SecretCLI(DockerCLICaller):
         full_cmd += [name, file]
         return Secret(self.client_config, run(full_cmd), is_immutable_id=True)
 
-    def inspect(self, x: Union[str, List[str]]) -> Union[Secret, List[Secret]]:
+    @overload
+    def inspect(self, x: str) -> Secret: ...
+
+    @overload
+    def inspect(self, x: Iterable[str]) -> List[Secret]: ...
+
+    def inspect(
+        self, x: Union[str, Iterable[str]]
+    ) -> Union[Secret, List[Secret]]:
         """Returns one or more `python_on_whales.Secret` based on an ID or name.
 
         Parameters:
             x: One or more IDs/names.
         """
-        if isinstance(x, list):
-            return [Secret(self.client_config, reference) for reference in x]
-        else:
+        if isinstance(x, str):
             return Secret(self.client_config, x)
+        else:
+            return [Secret(self.client_config, reference) for reference in x]
 
     def list(
         self, filters: Union[Iterable[SecretListFilter], Mapping[str, Any]] = ()
@@ -131,14 +140,15 @@ class SecretCLI(DockerCLICaller):
         ids = run(full_cmd).splitlines()
         return [Secret(self.client_config, id_, is_immutable_id=True) for id_ in ids]
 
-    def remove(self, x: Union[ValidSecret, List[ValidSecret]]) -> None:
+    def remove(self, x: Union[ValidSecret, Iterable[ValidSecret]]) -> None:
         """Removes one or more secrets
 
         Parameters:
             x: One or more secrets.
                 Name, ids or `python_on_whales.Secret` objects are valid inputs.
         """
-        if x == []:
+        secrets = to_list(x)
+        if not secrets:
             return
-        full_cmd = self.docker_cmd + ["secret", "remove"] + to_list(x)
+        full_cmd = self.docker_cmd + ["secret", "remove"] + secrets
         run(full_cmd)


### PR DESCRIPTION
Follows #595, #599, #627, working on #584.

Applies the same `Iterable`/`Mapping` treatment to the secret component:

- `SecretCLI.create(labels=...)`: `Dict[str, str]` -> `Mapping[str, str]`
- `SecretCLI.inspect(x)`: `List[str]` -> `Iterable[str]`, with `@overload` so a `str` argument is typed back to `Secret` and an iterable to `List[Secret]` (matches the pod component shape from #599).
- `SecretCLI.remove(x)`: `List[ValidSecret]` -> `Iterable[ValidSecret]`. The empty-input shortcut moves from `x == []` to `to_list(x)` + emptiness check, since iterables are not equality-comparable to a list and would otherwise have raised on a generator.

`inspect`'s runtime branch flips from `isinstance(x, list)` to `isinstance(x, str)`, which correctly accepts any non-string iterable (tuple, set, generator, mapping keys) instead of silently treating them as a single id. `to_list` already handles `str`/`bytes`/`Iterable` correctly for `remove`.

No public-API breakage: callers passing lists keep working; type-checkers stop complaining about invariant `List[ValidSecret]` arguments (the original mypy issue in #584).
