### PR TITLE
Support cpuset strings on container create/run/update and pod create (#626)

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -48,6 +48,7 @@ from python_on_whales.utils import (
     ValidPath,
     ValidPortMapping,
     custom_parse_object_as,
+    format_cpuset,
     format_port_arg,
     format_signal_arg,
     format_time_arg,
@@ -459,8 +460,8 @@ class RunArgs(TypedDict, total=False):
     cpu_rt_runtime: Optional[int]
     cpu_shares: Optional[int]
     cpus: Optional[float]
-    cpuset_cpus: Optional[List[int]]
-    cpuset_mems: Optional[List[int]]
+    cpuset_cpus: Union[List[int], str, None]
+    cpuset_mems: Union[List[int], str, None]
     devices: Iterable[str]
     device_cgroup_rules: Iterable[str]
     device_read_bps: Iterable[str]
@@ -678,8 +679,8 @@ class ContainerCLI(DockerCLICaller):
         cpu_rt_runtime: Optional[int] = None,
         cpu_shares: Optional[int] = None,
         cpus: Optional[float] = None,
-        cpuset_cpus: Optional[List[int]] = None,
-        cpuset_mems: Optional[List[int]] = None,
+        cpuset_cpus: Union[List[int], str, None] = None,
+        cpuset_mems: Union[List[int], str, None] = None,
         detach: bool = False,
         devices: Iterable[str] = (),
         device_cgroup_rules: Iterable[str] = (),
@@ -823,8 +824,8 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_simple_arg("--cpu-rt-runtime", cpu_rt_runtime)
         full_cmd.add_simple_arg("--cpu-shares", cpu_shares)
         full_cmd.add_simple_arg("--cpus", cpus)
-        full_cmd.add_simple_arg("--cpuset-cpus", join_if_not_none(cpuset_cpus))
-        full_cmd.add_simple_arg("--cpuset-mems", join_if_not_none(cpuset_mems))
+        full_cmd.add_simple_arg("--cpuset-cpus", format_cpuset(cpuset_cpus))
+        full_cmd.add_simple_arg("--cpuset-mems", format_cpuset(cpuset_mems))
 
         full_cmd.add_flag("--detach", detach)
 
@@ -1508,8 +1509,8 @@ class ContainerCLI(DockerCLICaller):
         cpu_rt_runtime: Optional[int] = None,
         cpu_shares: Optional[int] = None,
         cpus: Optional[float] = None,
-        cpuset_cpus: Optional[List[int]] = None,
-        cpuset_mems: Optional[List[int]] = None,
+        cpuset_cpus: Union[List[int], str, None] = None,
+        cpuset_mems: Union[List[int], str, None] = None,
         detach: bool = False,
         devices: Iterable[str] = (),
         device_cgroup_rules: Iterable[str] = (),
@@ -1681,8 +1682,12 @@ class ContainerCLI(DockerCLICaller):
             cpu_shares: CPU shares (relative weight)
             cpus: The maximal amount of cpu the container can use.
                 `1` means one cpu core.
-            cpuset_cpus: CPUs in which to allow execution. Must be given as a list.
-            cpuset_mems: MEMs in which to allow execution. Must be given as a list.
+            cpuset_cpus: CPUs in which to allow execution. Accepts a list of
+                CPU indices (e.g. `[0, 2]`) or a cpuset string as understood by
+                the docker CLI (e.g. `"0-3"`, `"0,2"`, `"0-3,7"`).
+            cpuset_mems: MEMs in which to allow execution. Accepts a list of
+                memory-node indices or a cpuset string (same format as
+                `cpuset_cpus`).
             detach: If `False`, returns the ouput of the container as a string.
                 If `True`, returns a `python_on_whales.Container` object.
             dns_search: Set custom DNS search domains
@@ -1809,8 +1814,8 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_simple_arg("--cpu-rt-runtime", cpu_rt_runtime)
         full_cmd.add_simple_arg("--cpu-shares", cpu_shares)
         full_cmd.add_simple_arg("--cpus", cpus)
-        full_cmd.add_simple_arg("--cpuset-cpus", join_if_not_none(cpuset_cpus))
-        full_cmd.add_simple_arg("--cpuset-mems", join_if_not_none(cpuset_mems))
+        full_cmd.add_simple_arg("--cpuset-cpus", format_cpuset(cpuset_cpus))
+        full_cmd.add_simple_arg("--cpuset-mems", format_cpuset(cpuset_mems))
 
         full_cmd.add_flag("--detach", detach)
 
@@ -2151,8 +2156,11 @@ class ContainerCLI(DockerCLICaller):
             cpu_shares: CPU shares (relative weight)
             cpus: The maximal amount of cpu the container can use.
                 `1` means one cpu core.
-            cpuset_cpus: CPUs in which to allow execution. Must be given as a list.
-            cpuset_mems: MEMs in which to allow execution. Must be given as a list.
+            cpuset_cpus: CPUs in which to allow execution, as a cpuset string
+                understood by the docker CLI (e.g. `"0-3"`, `"0,2"`,
+                `"0-3,7"`).
+            cpuset_mems: MEMs in which to allow execution, as a cpuset string
+                (same format as `cpuset_cpus`).
             memory:  Memory limit, valid values are `1024` (ints are bytes) or
                 `"43m"` or `"6g"`.
             memory_reservation: Memory soft limit

--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -52,7 +52,6 @@ from python_on_whales.utils import (
     format_port_arg,
     format_signal_arg,
     format_time_arg,
-    join_if_not_none,
     removeprefix,
     run,
     stream_stdout_and_stderr,

--- a/python_on_whales/components/pod/cli_wrapper.py
+++ b/python_on_whales/components/pod/cli_wrapper.py
@@ -39,7 +39,6 @@ from python_on_whales.utils import (
     format_port_arg,
     format_signal_arg,
     format_time_arg,
-    join_if_not_none,
     run,
     stream_stdout_and_stderr,
     to_list,

--- a/python_on_whales/components/pod/cli_wrapper.py
+++ b/python_on_whales/components/pod/cli_wrapper.py
@@ -35,6 +35,7 @@ from python_on_whales.exceptions import NoSuchPod
 from python_on_whales.utils import (
     ValidPath,
     ValidPortMapping,
+    format_cpuset,
     format_port_arg,
     format_signal_arg,
     format_time_arg,
@@ -259,7 +260,7 @@ class PodCLI(DockerCLICaller):
         add_hosts: Iterable[Tuple[str, str]] = (),
         cgroup_parent: Optional[str] = None,
         cpus: Optional[float] = None,
-        cpuset_cpus: Optional[Iterable[int]] = None,
+        cpuset_cpus: Union[Iterable[int], str, None] = None,
         devices: Iterable[str] = (),
         device_read_bps: Iterable[str] = (),
         dns: Iterable[str] = (),
@@ -319,7 +320,9 @@ class PodCLI(DockerCLICaller):
                 be relative to the cgroups path of the init process.
             cpus: Set the total number of CPUs delegated to the pod. The default
                 is 0.0 indicating that there is no limit on computation power.
-            cpuset_cpus: CPUs in which to allow execution.
+            cpuset_cpus: CPUs in which to allow execution. Accepts a list of
+                CPU indices (e.g. `[0, 2]`) or a cpuset string as understood by
+                the CLI (e.g. `"0-3"`, `"0,2"`, `"0-3,7"`).
             devices: List of device names to pass from the host to containers
                 in the pod.
             device_read_bps: Limit read rate (in bytes per second) from a device
@@ -403,7 +406,7 @@ class PodCLI(DockerCLICaller):
         )
         full_cmd.add_simple_arg("--cgroup-parent", cgroup_parent)
         full_cmd.add_simple_arg("--cpus", cpus)
-        full_cmd.add_simple_arg("--cpuset-cpus", join_if_not_none(cpuset_cpus))
+        full_cmd.add_simple_arg("--cpuset-cpus", format_cpuset(cpuset_cpus))
         full_cmd.add_args_iterable("--device", devices)
         full_cmd.add_args_iterable("--device-read-bps", device_read_bps)
         full_cmd.add_args_iterable("--dns", dns)

--- a/python_on_whales/utils.py
+++ b/python_on_whales/utils.py
@@ -442,6 +442,12 @@ def join_if_not_none(sequence: Optional[list]) -> Optional[str]:
     return ",".join(sequence)
 
 
+def format_cpuset(value: Union[Iterable[int], str, None]) -> Optional[str]:
+    if value is None or isinstance(value, str):
+        return value
+    return ",".join(str(x) for x in value)
+
+
 def to_seconds(duration: Optional[Union[int, timedelta]]) -> Optional[str]:
     if duration is None:
         return None

--- a/tests/python_on_whales/test_utils.py
+++ b/tests/python_on_whales/test_utils.py
@@ -1,5 +1,33 @@
 import python_on_whales.utils
-from python_on_whales.utils import ProcessStream, stream_stdout_and_stderr
+from python_on_whales.utils import (
+    ProcessStream,
+    format_cpuset,
+    stream_stdout_and_stderr,
+)
+
+
+def test_format_cpuset_none():
+    assert format_cpuset(None) is None
+
+
+def test_format_cpuset_list_of_ints():
+    assert format_cpuset([0, 2, 3]) == "0,2,3"
+
+
+def test_format_cpuset_empty_list():
+    assert format_cpuset([]) == ""
+
+
+def test_format_cpuset_string_passthrough():
+    # cpuset strings accepted by the CLI must be passed through unmodified so
+    # ranges like "0-3" and mixes like "0-3,7" reach docker as-is.
+    assert format_cpuset("0-3") == "0-3"
+    assert format_cpuset("0,2") == "0,2"
+    assert format_cpuset("0-3,7") == "0-3,7"
+
+
+def test_format_cpuset_generator():
+    assert format_cpuset(iter([1, 4])) == "1,4"
 
 
 def test_environment_variables_propagation(monkeypatch):


### PR DESCRIPTION
Closes #626.

## Summary

`cpuset_cpus` / `cpuset_mems` on `container.create()`, `container.run()` and `pod.create()` only accepted `List[int]`, so users couldn't pass the range/mixed cpuset strings the Docker CLI actually supports (`"0-3"`, `"0,2"`, `"0-3,7"`). This PR widens the accepted types and adds a small `format_cpuset` helper that passes strings through unchanged and joins integer iterables.

`container.update()` was already typed `Optional[str]` on master but its docstring still claimed it required a list — that's corrected too.

## Design note

Issue #626 suggested making this **string-only** (a backwards-incompatible change). I went with `Union[List[int], str, None]` instead to keep existing list-based callers working. Happy to drop `List[int]` and make it string-only with a deprecation if you'd prefer — let me know and I'll push a follow-up commit.

## Changes

- New `format_cpuset()` util in `python_on_whales/utils.py`
- `container.create()`, `container.run()`: widened `cpuset_cpus` / `cpuset_mems` to `Union[List[int], str, None]`, switched call-sites to `format_cpuset`
- `pod.create()`: widened `cpuset_cpus` to `Union[Iterable[int], str, None]`
- `container.update()`: docstring corrected (signature was already `Optional[str]`)
- Unit tests for `format_cpuset` covering None / list / empty / string / generator
