### PR TITLE
Support for 'docker compose publish' command

### DIFF
--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -531,6 +531,32 @@ class ComposeCLI(DockerCLICaller):
             for proj in json.loads(run(full_cmd))
         ]
 
+    def publish(
+        self,
+        repository: str,
+        oci_version: Optional[str] = None,
+        resolve_image_digests: bool = False,
+        with_env: bool = False,
+        yes: bool = False,
+    ) -> None:
+        """Publish compose application.
+
+        Parameters:
+            repository: Repository to publish compose application
+            oci_version: OCI image/artifact specification version (automatically determined by default)
+            resolve_image_digests: Pin image tags to digests
+            with_env: Include environment variables in the published OCI artifact
+            yes: Assume "yes" as answer to all prompts
+        """
+        full_cmd = self.docker_compose_cmd + ["publish"]
+        if oci_version is not None:
+            full_cmd.add_simple_arg("--oci-version", oci_version)
+        full_cmd.add_flag("--resolve-image-digests", resolve_image_digests)
+        full_cmd.add_flag("--with-env", with_env)
+        full_cmd.add_flag("--yes", yes)
+        full_cmd.append(repository)
+        run(full_cmd, capture_stderr=False, capture_stdout=False)
+
     @overload
     def pull(
         self,
@@ -969,6 +995,7 @@ class ComposeCLI(DockerCLICaller):
         stream_logs: Literal[True] = ...,
         wait_timeout: Optional[int] = ...,
         dependencies: bool = True,
+        yes: bool = ...,
     ) -> Iterable[Tuple[str, bytes]]: ...
 
     @overload
@@ -995,6 +1022,7 @@ class ComposeCLI(DockerCLICaller):
         stream_logs: Literal[False] = ...,
         wait_timeout: Optional[int] = ...,
         dependencies: bool = True,
+        yes: bool = ...,
     ) -> None: ...
 
     def up(
@@ -1020,6 +1048,7 @@ class ComposeCLI(DockerCLICaller):
         stream_logs: bool = False,
         wait_timeout: Optional[int] = None,
         dependencies: bool = True,
+        yes: bool = False,
     ):
         """Start the containers.
 
@@ -1066,6 +1095,7 @@ class ComposeCLI(DockerCLICaller):
                 not familiar with the streaming of logs in Python-on-whales.
             wait_timeout: Maximum duration to wait for the project to be running|healthy
             dependencies: Also start linked services.
+            yes: If `True` assume "yes" as answer to all prompts and run non-interactively.
         """
         if quiet and stream_logs:
             raise ValueError(
@@ -1090,6 +1120,7 @@ class ComposeCLI(DockerCLICaller):
         full_cmd.add_flag("--remove-orphans", remove_orphans)
         full_cmd.add_flag("--renew-anon-volumes", renew_anon_volumes)
         full_cmd.add_flag("--no-deps", not dependencies)
+        full_cmd.add_flag("--yes", yes)
         full_cmd.add_simple_arg("--pull", pull)
 
         if no_attach_services is not None:

--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -995,7 +995,7 @@ class ComposeCLI(DockerCLICaller):
         stream_logs: Literal[True] = ...,
         wait_timeout: Optional[int] = ...,
         dependencies: bool = True,
-        yes: bool = ...,
+        use_default_sensitive_values: bool = ...,
     ) -> Iterable[Tuple[str, bytes]]: ...
 
     @overload
@@ -1022,7 +1022,7 @@ class ComposeCLI(DockerCLICaller):
         stream_logs: Literal[False] = ...,
         wait_timeout: Optional[int] = ...,
         dependencies: bool = True,
-        yes: bool = ...,
+        use_default_sensitive_values: bool = ...,
     ) -> None: ...
 
     def up(
@@ -1048,7 +1048,7 @@ class ComposeCLI(DockerCLICaller):
         stream_logs: bool = False,
         wait_timeout: Optional[int] = None,
         dependencies: bool = True,
-        yes: bool = False,
+        use_default_sensitive_values: bool = False,
     ):
         """Start the containers.
 
@@ -1095,7 +1095,7 @@ class ComposeCLI(DockerCLICaller):
                 not familiar with the streaming of logs in Python-on-whales.
             wait_timeout: Maximum duration to wait for the project to be running|healthy
             dependencies: Also start linked services.
-            yes: If `True` assume "yes" as answer to all prompts and run non-interactively.
+            use_default_sensitive_values: If `True` assume "yes" as answer to all prompts and run non-interactively.
         """
         if quiet and stream_logs:
             raise ValueError(
@@ -1120,7 +1120,7 @@ class ComposeCLI(DockerCLICaller):
         full_cmd.add_flag("--remove-orphans", remove_orphans)
         full_cmd.add_flag("--renew-anon-volumes", renew_anon_volumes)
         full_cmd.add_flag("--no-deps", not dependencies)
-        full_cmd.add_flag("--yes", yes)
+        full_cmd.add_flag("--yes", use_default_sensitive_values)
         full_cmd.add_simple_arg("--pull", pull)
 
         if no_attach_services is not None:

--- a/python_on_whales/components/compose/cli_wrapper.py
+++ b/python_on_whales/components/compose/cli_wrapper.py
@@ -537,7 +537,7 @@ class ComposeCLI(DockerCLICaller):
         oci_version: Optional[str] = None,
         resolve_image_digests: bool = False,
         with_env: bool = False,
-        yes: bool = False,
+        allow_publishing_sensitive_data: bool = False,
     ) -> None:
         """Publish compose application.
 
@@ -546,14 +546,14 @@ class ComposeCLI(DockerCLICaller):
             oci_version: OCI image/artifact specification version (automatically determined by default)
             resolve_image_digests: Pin image tags to digests
             with_env: Include environment variables in the published OCI artifact
-            yes: Assume "yes" as answer to all prompts
+            allow_publishing_sensitive_data: Assume "yes" as answer to all prompts
         """
         full_cmd = self.docker_compose_cmd + ["publish"]
         if oci_version is not None:
             full_cmd.add_simple_arg("--oci-version", oci_version)
         full_cmd.add_flag("--resolve-image-digests", resolve_image_digests)
         full_cmd.add_flag("--with-env", with_env)
-        full_cmd.add_flag("--yes", yes)
+        full_cmd.add_flag("--yes", allow_publishing_sensitive_data)
         full_cmd.append(repository)
         run(full_cmd, capture_stderr=False, capture_stdout=False)
 

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -1475,7 +1475,7 @@ def test_compose_publish_cli_all_flags(run_mock: Mock):
         oci_version="1.1.0",
         resolve_image_digests=True,
         with_env=True,
-        yes=True,
+        allow_publishing_sensitive_data=True,
     )
 
     run_mock.assert_called_once_with(
@@ -1511,7 +1511,11 @@ def test_docker_compose_publish():
         detach=True,
         name="test_registry_container",
     ):
-        docker.compose.publish("localhost:5000/repo/app:tag", with_env=True, yes=True)
+        docker.compose.publish(
+            "localhost:5000/repo/app:tag",
+            with_env=True,
+            allow_publishing_sensitive_data=True,
+        )
 
         app_client = DockerClient(compose_files=["oci://localhost:5000/repo/app:tag"])
         app_client.compose.pull()

--- a/tests/python_on_whales/components/test_compose.py
+++ b/tests/python_on_whales/components/test_compose.py
@@ -1453,6 +1453,72 @@ def test_build_args():
     assert config.services["my_service"].environment == {"DATADOG_HOST": "something"}
 
 
+@patch("python_on_whales.components.compose.cli_wrapper.run")
+def test_compose_publish_cli_basic(run_mock: Mock):
+    test_application = "repo/app:tag"
+    docker.compose.publish(test_application)
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_compose_cmd
+        + [
+            "publish",
+            test_application,
+        ],
+        capture_stderr=False,
+        capture_stdout=False,
+    )
+
+
+@patch("python_on_whales.components.compose.cli_wrapper.run")
+def test_compose_publish_cli_all_flags(run_mock: Mock):
+    docker.compose.publish(
+        repository="repo/image:tag",
+        oci_version="1.1.0",
+        resolve_image_digests=True,
+        with_env=True,
+        yes=True,
+    )
+
+    run_mock.assert_called_once_with(
+        docker.client_config.docker_compose_cmd
+        + [
+            "publish",
+            "--oci-version",
+            "1.1.0",
+            "--resolve-image-digests",
+            "--with-env",
+            "--yes",
+            "repo/image:tag",
+        ],
+        capture_stderr=False,
+        capture_stdout=False,
+    )
+
+
+def test_docker_compose_publish():
+    docker = DockerClient(
+        compose_files=[
+            PROJECT_ROOT
+            / "tests/python_on_whales/components/dummy_compose_with_container_names.yml"
+        ],
+        compose_compatibility=True,
+    )
+
+    with docker.run(
+        "registry:3",
+        remove=True,
+        privileged=False,
+        publish=[(5000, 5000)],
+        detach=True,
+        name="test_registry_container",
+    ):
+        docker.compose.publish("localhost:5000/repo/app:tag", with_env=True, yes=True)
+
+        app_client = DockerClient(compose_files=["oci://localhost:5000/repo/app:tag"])
+        app_client.compose.pull()
+        app_client.compose.up(detach=True)
+        app_client.compose.rm(stop=True)
+
+
 COMPOSE_WD_FIXTURE_DIR = (
     PROJECT_ROOT / "tests/python_on_whales/components/build_with_dependencies_test"
 )


### PR DESCRIPTION
Hi!

This PR adds support for the Docker Compose `publish` command, allowing users to version and distribute Compose YAML files using automation scripts and `python-on-whales`. 

I've recently discovered this Docker Compose feature and realized that it is quite useful for some workflows at work — and since we're already using `python-on-whales` extensively, adding support to it made perfect sense. Besides all, it also increases the compliance levels of the library with the Docker Compose CLI.

Here's the `help` for the mentioned command:

```bash
$ docker compose publish --help
Usage:  docker compose publish [OPTIONS] REPOSITORY[:TAG]

Publish compose application
```

As an usage example, consider the following Compose file:

```yaml
# example_deployment.yml
---
services:
  hello:
    image: alpine:latest
    environment:
      NAME: ${NAME}
    command: sh -c 'while true; do echo "$$NAME"; sleep 5; done'
```

With the proposed changes, users can now distribute their Compose applications as follows:

```python
>>> from python_on_whales import DockerClient
>>> # ...
>>> docker = DockerClient(compose_files=["example_deployment.yml"])
>>> docker.compose.publish("docker.io/username/my-application:v0.0.1", yes=True)
```

All available command options are supported (e.g., the flag `--yes` in the example above to bypass interactive prompts in automated contexts).

Also with the proposed changes, users may download and use published applications as follows:

```python
>>> import os
>>> from python_on_whales import DockerClient
>>> docker = DockerClient(compose_files=["oci://docker.io/username/my-application:v0.0.1"])
>>> # ...
>>> os.environ["NAME"] = "DODO"
>>> # ...
>>> docker.compose.up(yes=True)
[+] Running 1/1
 ✔ Container components-hello-1  
 Created                   0.0s 
Attaching to hello-1
hello-1  | DODO
hello-1  | DODO
hello-1  | DODO
```

Additionally, I've added the missing flag `--yes` to existing command `docker.compose.up`.

The PR includes unit tests for the newly added logic and documentation as per the Docker Compose CLI.

Let me know what you think of it all.
Thanks!