### PR TITLE
Add `allow` argument to `docker.buildx.bake` (#722)

### DIFF
--- a/python_on_whales/components/buildx/cli_wrapper.py
+++ b/python_on_whales/components/buildx/cli_wrapper.py
@@ -125,6 +125,7 @@ class BuildxCLI(DockerCLICaller):
     def bake(
         self,
         targets: Union[str, List[str]] = [],
+        allow: Union[str, List[str]] = [],
         builder: Optional[ValidBuilder] = None,
         files: Union[ValidPath, List[ValidPath]] = [],
         load: bool = False,
@@ -148,6 +149,10 @@ class BuildxCLI(DockerCLICaller):
 
         Parameters:
             targets: Targets or groups of targets to build.
+            allow: Entitlements to grant to the build, as a string or a list of
+                strings. Needed for example when a bake target reads a secret
+                outside of the build context.
+                Eg `allow=["fs.read=/home/my_user/.netrc", "network.host"]`
             builder: The builder to use.
             files: Build definition file(s)
             load: Shorthand for `set=["*.output=type=docker"]`
@@ -201,6 +206,7 @@ class BuildxCLI(DockerCLICaller):
         full_cmd = self.docker_cmd + ["buildx", "bake"]
 
         full_cmd.add_flag("--no-cache", not cache)
+        full_cmd.add_args_iterable_or_single("--allow", allow)
         full_cmd.add_simple_arg("--builder", builder)
         full_cmd.add_flag("--load", load)
         full_cmd.add_flag("--pull", pull)

--- a/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
+++ b/tests/python_on_whales/components/buildx/test_buildx_cli_wrapper.py
@@ -809,6 +809,66 @@ def test_bake_metadata_file_str_path_option(only_print, monkeypatch, tmp_path):
 
 
 @pytest.mark.usefixtures("with_docker_driver")
+@pytest.mark.usefixtures("change_cwd")
+@pytest.mark.parametrize("only_print", [True, False])
+def test_bake_without_allow_option(only_print, monkeypatch):
+    recorded = {}
+
+    def fake_run(cmd, capture_stderr=True, env={}):
+        recorded["cmd"] = list(cmd)
+        return "{}"
+
+    monkeypatch.setattr(python_on_whales.components.buildx.cli_wrapper, "run", fake_run)
+
+    docker.buildx.bake(files=[bake_file], print=only_print)
+
+    assert "--allow" not in recorded.get("cmd", [])
+
+
+@pytest.mark.usefixtures("with_docker_driver")
+@pytest.mark.usefixtures("change_cwd")
+@pytest.mark.parametrize("only_print", [True, False])
+def test_bake_allow_single_option(only_print, monkeypatch):
+    recorded = {}
+
+    def fake_run(cmd, capture_stderr=True, env={}):
+        recorded["cmd"] = list(cmd)
+        return "{}"
+
+    monkeypatch.setattr(python_on_whales.components.buildx.cli_wrapper, "run", fake_run)
+
+    docker.buildx.bake(files=[bake_file], print=only_print, allow="network.host")
+
+    cmd = list(map(str, recorded.get("cmd", [])))
+    assert cmd.count("--allow") == 1
+    assert cmd[cmd.index("--allow") + 1] == "network.host"
+
+
+@pytest.mark.usefixtures("with_docker_driver")
+@pytest.mark.usefixtures("change_cwd")
+@pytest.mark.parametrize("only_print", [True, False])
+def test_bake_allow_multiple_options(only_print, monkeypatch):
+    recorded = {}
+
+    def fake_run(cmd, capture_stderr=True, env={}):
+        recorded["cmd"] = list(cmd)
+        return "{}"
+
+    monkeypatch.setattr(python_on_whales.components.buildx.cli_wrapper, "run", fake_run)
+
+    docker.buildx.bake(
+        files=[bake_file],
+        print=only_print,
+        allow=["fs.read=/tmp/some_file", "network.host"],
+    )
+
+    cmd = list(map(str, recorded.get("cmd", [])))
+    assert cmd.count("--allow") == 2
+    assert "fs.read=/tmp/some_file" in cmd
+    assert "network.host" in cmd
+
+
+@pytest.mark.usefixtures("with_docker_driver")
 @pytest.mark.usefixtures("prune_all")
 def test_prune_all_empty():
     logs = docker.buildx.prune(all=True, stream_logs=True)


### PR DESCRIPTION
Without it, bake targets needing entitlements (e.g. a secret whose src is outside the build context) block on an interactive confirmation prompt. Accepts a string or a list, like the existing `allow` of `build()`.

Fixes an issue here: https://github.com/gabrieldemarmiesse/python-on-whales/pull/722